### PR TITLE
Move elements of mapper triggers to new class

### DIFF
--- a/Copy These to Genie's Scripts Folder/automapper.cmd
+++ b/Copy These to Genie's Scripts Folder/automapper.cmd
@@ -1,9 +1,24 @@
 # automapper.cmd
-var autoversion 8.2025-02-09
+var autoversion 8.2025-08-08
 # use '.automapper help' from the command line for variables and more
 # debug 5 is for outlander; genie debuglevel 10
 # debuglevel 10
 # debug 5
+
+#2025-08-08
+# Maje
+#   created new class (move) to handle depth updates
+#   solves errors related to additional typeahead when doing special areas like skating
+
+#2025-08-07
+# Hanryu
+#   swap to gametime timeous after Maje showed that unixtime timeouts don't work on genie
+#   genie4 issue #179
+#   also fancier vela'tohr fix for the permanent plant in empaths
+
+#2025-08-04
+# Hanryu
+#   swap to evalmath on every instance of eval var a + b
 
 #2025-02-09
 # Hanryu
@@ -560,8 +575,8 @@ ABSOLUTE.TOP:
   var move_INVIS ^The .* can't see you\!|^But no one can see you\!|^How can you .* can't even see you\?|^You can't move in that direction while unseen\.
   var climb_mount_FAIL climb what?
 ACTIONS:
-  action (mapper) action (mapper) off;goto DRAGGED when ^The current drags you
-  action (mapper) if (%movewait = 0) then shift;if (%movewait = 0) then math depth subtract 1;if ((%verbose) && (len("%2") > 0)) then put #echo %color Next move: %2 when %move_OK
+  action (move) action (move) off;goto DRAGGED when ^The current drags you
+  action (move) if (%movewait = 0) then shift;if (%movewait = 0) then math depth subtract 1;if ((%verbose) && (len("%2") > 0)) then put #echo %color Next move: %2 when %move_OK
   action (mapper) goto MOVE.FAILED when %move_FAIL
   action (mapper) var TryGoInsteadOfClimb 1 when ^You can't climb that\.$
   action (mapper) goto MOVE.RETRY when %move_RETRY|%move_WEB|^You can't climb that\.$
@@ -588,7 +603,7 @@ ACTIONS:
   action (mapper) var footitem $1;goto STOW.FOOT.ITEM when ^You notice (?:an |a )?(.+) at your feet, and do not wish to leave it behind\.
   action (skates) var wearing_skates 1 when ^You slide your ice skates on your feet and tightly tie the laces\.|^Your ice skates help you traverse the frozen terrain\.|^Your movement is hindered .* by your ice skates\.|^You tap some.*\bskates\b.*that you are wearing
   action (skates) var wearing_skates 0 when ^You untie your skates and slip them off of your feet\.
-  action (healing) var plant $1;goto HEALING when (vela'tohr (?:briar|bush|plant|shrub|thicket|thornbush))
+  action (healing) var plant $1;goto HEALING when ((?:a|an)\s(?!large\svela'tohr\splant)(?:[\w']+\s)*vela'tohr\s(?:[\w']+\s)*(thicket|plant|thornbush|briar|bush|shrub))
   action (healing) off
 #  if (($automapper.seekhealing = 1) && ($guild != Necromancer)) then action (healing) on
   if ($automapper.seekhealing = 1) then action (healing) on
@@ -708,11 +723,11 @@ DO.MOVE:
   goto MOVE.DONE
 
 MOVE.ROOM:
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   put %movement
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 0) then waiteval ((0 = %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 0) then waiteval ((0 = %depth) || ($gametime >= %depthtimeout))
   goto MOVE.DONE
 
 MOVE.STOW:
@@ -739,14 +754,10 @@ MOVE.BOAT.ARRIVED:
 MOVE.ICE:
   if (!$broom_carpet) then {
     action (skates) on
-    eval depthtimeout $unixtime + %waitevalTimeOut
-    if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
     if (!%skatechecked) then gosub FIND.SKATES
     if (%slow_on_ice) then gosub ICE.COLLECT
   }
   put %movement
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 0) then waiteval ((0 = %depth) || ($unixtime >= %depthtimeout))
   goto MOVE.DONE
 
 SKATE.NO:
@@ -782,8 +793,8 @@ ICE.PAUSE:
 MOVE.KNOCK:
   action (mapper) off
   if ($roundtime > 0) then pause %command_pause
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   if !matchre("$citizenship", "Ilithi|Fayrin's Rest|Shard|Steelclaw Clan|Zaldi Taipa") then goto SHARD.FAILED
   var movement knock gate
   matchre MOVE.KNOCK ^\.\.\.wait|^Sorry,|^You are still stun|^You can't do that while entangled
@@ -829,8 +840,8 @@ MOVE.SWIM:
 MOVE.RT:
 ####added this to stop trainer
   eval movement replacere("%movement", "script crossingtrainerfix ", "")
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   matchre MOVE.RT.SUCCESS ^(?:Obvious|Ship) (?:paths|exits):
   put %movement
   matchwait 15
@@ -908,8 +919,8 @@ STOW.ROPE:
 MOVE.SEARCH:
 #maybe the path is already open, let's try that first, then waste time searching
   if ($broom_carpet) then eval movement replacere("%movement", "climb ", "go ")
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   action (mapper) off
   matchre MOVE.SEARCH2 %move_FAIL
   matchre MOVE.SEARCH.PATHOPEN %move_OK
@@ -981,8 +992,8 @@ MOVE.OBJSEARCH:
 
 MOVE.SCRIPT:
   var subscript 1
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   action (mapper) off
   if ("%movement" = "oshumanor") then goto OSHUMANOR
   if ("%movement" = "dragonspine") then goto DRAGONSPINE
@@ -1056,8 +1067,8 @@ FATIGUE.WAIT:
   goto FATIGUE.WAIT
 
 MOVE.INVIS:
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   if ("$guild" = "Necromancer") then {
     gosub PUT release EOTB
     pause %command_pause
@@ -1477,8 +1488,8 @@ ARMOIRE:
 MISTWOOD.CLIFF:
 #shift away if room load trigger got turned off before it loaded
   if matchre("%1", "objsearch rocky.ledge climb shrub") then shift
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   put peer path
   waitforre ^Peering closely at a faint path, you realize you would need to head (\w+)\.
   var Dir $1
@@ -1959,7 +1970,7 @@ BAG.NEXT:
 DRAGGED:
   delay %infiniteLoopProtection
   if ($roundtime > 0) then pause $roundtime
-  action (mapper) on
+  action (move) on
   var depth 0
   goto MOVE.DONE
 ####
@@ -2306,8 +2317,8 @@ LIGHT_ROOM:
 HEALING:
   delay %infiniteLoopProtection
   if ($roundtime > 0) then pause $roundtime
-  eval depthtimeout $unixtime + %waitevalTimeOut
-  if (%depth > 1) then waiteval ((1 <= %depth) || ($unixtime >= %depthtimeout))
+  evalmath depthtimeout $unixtime + %waitevalTimeOut
+  if (%depth > 1) then waiteval ((1 <= %depth) || ($gametime >= %depthtimeout))
   var action touch %plant
   var success ^The last of your wounds knit shut|^The vela'tohr plant recoils from you|^You reach out to touch an ethereal vela'tohr plant, but it shudders its leaves rustling angrily and bristling with sharp edges and thorns|^You feel a brief flare of warmth where your skin previously
   gosub ACTION


### PR DESCRIPTION
created new class (move) to handle depth updates
solves errors related to additional typeahead when doing special areas like skating