### PR TITLE
Standardize room colors: convert named colors to hex, remove undocumented White

### DIFF
--- a/Map108_M'Riss.xml
+++ b/Map108_M'Riss.xml
@@ -2883,19 +2883,19 @@
     <arc exit="southwest" move="southwest" destination="417" />
     <arc exit="northwest" move="northwest" destination="415" />
   </node>
-  <node id="419" name="The West Face, A Narrow Channel" color="White">
+  <node id="419" name="The West Face, A Narrow Channel">
     <description>The channel bears signs of having been at least improved, if not created, by intention.  In some places, small steps have been hacked in the rock, but either the project was unfinished or it was intended for some creature whose limbs are hard to imagine.</description>
     <position x="-240" y="120" z="0" />
     <arc exit="climb" move="climb down" destination="420" />
     <arc exit="climb" move="climb up" destination="279" />
   </node>
-  <node id="420" name="The West Face, A Rocky Ledge" color="White">
+  <node id="420" name="The West Face, A Rocky Ledge">
     <description>Midway up the cliff face juts a rocky ledge, only a few feet wide and perhaps ten or twelve feet long.  Above it, a narrow channel carved into the rock leads upwards out of sight.  Further to the east, a much steeper and natural-looking crevice in the rock leads downward to the river bank.</description>
     <position x="-240" y="140" z="0" />
     <arc exit="east" move="east" destination="421" />
     <arc exit="climb" move="climb up" destination="419" />
   </node>
-  <node id="421" name="The West Face, A Rocky Ledge" color="White">
+  <node id="421" name="The West Face, A Rocky Ledge">
     <description>Midway up the cliff face juts a rocky ledge, only a few feet wide and perhaps ten or twelve feet long.  Below it, a narrow crevice in the rock leads downward to the river bank.  Further to the west, a channel in the cliff face leads upward out of sight.</description>
     <position x="-220" y="140" z="0" />
     <arc exit="west" move="west" destination="420" />
@@ -2907,42 +2907,42 @@
     <arc exit="up" move="up" destination="423" />
     <arc exit="climb" move="climb chimney rock" destination="271" />
   </node>
-  <node id="423" name="Galduta Isharon, Plateau" color="White">
+  <node id="423" name="Galduta Isharon, Plateau">
     <description>The plateau extends toward the horizon as a vast expanse of weathered granite.  To the northeast, the wide caldera of Undogoz Mountain pierces the sky, the smell of sulfur carried on the wind.  A ruined city lies like a cluster of broken teeth in the far east, near where the sea meets the sky.  In the southeast, the floating structures of Mer'Kresh drift within the sparkling waters of Torbis Sanhalas Bay.  Four weathered cyclopean megaliths stand in a geometric ring at the center of the rise.</description>
     <description>Cold wind sweeps across the plateau, the scent of salt drifting off of the sea.  To the northeast, the silhouette of Undogoz Mountain stands black against the night sky, looming over the dunes beyond.  The distant ruins to the east are lost in shadow, but the lights of Mer'Kresh glisten in the southeast bay.  Four towering megaliths cast long shadows.</description>
     <position x="90" y="185" z="1" />
     <arc exit="down" move="down" destination="422" />
     <arc exit="climb" move="climb downward escarpment" destination="424" />
   </node>
-  <node id="424" name="Galduta Isharon, Escarpment" color="White">
+  <node id="424" name="Galduta Isharon, Escarpment">
     <description>The plateau gives way to a precipitous descent where the ground fractures into a series of jagged, descending tiers.  Loose shale and granite blocks spill down the slope, forming a natural series of steps that wind toward the foothills of Undogoz Mountain.  Sunlight hits the steep face and reveals deep fissures carved into the rock by ice and snow.  The air feels thin here, and carries the acrid scent of sulfur.</description>
     <description>A tiered rockslide stretches from the plateau to the foothills of Undogoz Mountain, blocking the view of the peak.  Frost coats the granite, making the footing is hazardous in the dim light.  A wind whistles between crevices, carrying the scent of frozen earth.</description>
     <position x="105" y="185" z="1" />
     <arc exit="north" move="north" destination="425" />
     <arc exit="climb" move="climb rock ledge" destination="423" />
   </node>
-  <node id="425" name="Undogoz Mountain, Base Ascent" color="White">
+  <node id="425" name="Undogoz Mountain, Base Ascent">
     <description>Deciduous trees wind along craggy rock faces in the foothills, and carefully-carved steps in the stone wind steeply upward to the cliffs of the volcanic rim that stands above to the northeast.  The air smells of damp pine needles and cold earth.</description>
     <description>The tree canopy casts long, fractured shadows across carved stairs winding upward towards the mountain.  The air grows sharp and cold as it descends from the volcanic rim.  Deciduous branches sway, scraping against the stone with a dry, rhythmic sound.  The silhouette of the mountain looms above, its crags barely visible against the night sky.  The scent of pine lingers heavily in the stillness.</description>
     <position x="105" y="170" z="1" />
     <arc exit="south" move="south" destination="424" />
     <arc exit="climb" move="climb upward steps" destination="426" />
   </node>
-  <node id="426" name="Undogoz Mountain, Slope Ascent" color="White">
+  <node id="426" name="Undogoz Mountain, Slope Ascent">
     <description>The steps wind steeply upward, clinging to the side of a sheer rock wall.  Above, the volcanic rim looms, its sharp profile cutting against the sky.  A thin, icy trickle of water runs down the narrow stone stairs, making the surface slick.  There is a steep drop-off from the steps into the valley below.</description>
     <description>Darkness swallows the valley below, leaving only black space.  Slivers of cold light cast across the steps, highlighting the slick ice that coats the stone.  Wind moans through the gaps in the crags above, a constant, low-pitched sound.  The volcanic rim creates a jagged silhouette against the night sky.  Shadow hides the edges of the stairs, turning every footfall into a hazard.</description>
     <position x="120" y="170" z="1" />
     <arc exit="climb" move="climb upward steps" destination="427" />
     <arc exit="climb" move="climb downward steps" destination="425" />
   </node>
-  <node id="427" name="Undogoz Mountain, Narrow Ridge" color="White">
+  <node id="427" name="Undogoz Mountain, Narrow Ridge">
     <description>The staircase levels out onto a projection of granite that pivots at an angle.  Beyond the edge of the stone, the ground ceases, yielding to a drop that falls to the tree line below.  Wind sweeps along the cliff face and pushes the gravel scattered across the shelf.  The path turns against the mountain and continues upward toward the volcanic rim.</description>
     <description>The landing hangs above a sharp drop into darkness that obscures the valley floor.  The edge of the cliff vanishes into the black, leaving only treacherous exposed rock visible along either edge of the path.  Howling wind moves in the turn of the path, stirring what little plant life that holds on to the rock face.  The jagged crags above loom, their silhouette visible against the night sky as the trail resumes the climb.</description>
     <position x="120" y="160" z="1" />
     <arc exit="climb" move="climb upward steps" destination="428" />
     <arc exit="climb" move="climb downward steps" destination="426" />
   </node>
-  <node id="428" name="Undogoz Mountain, Breakneck Ridge" color="White">
+  <node id="428" name="Undogoz Mountain, Breakneck Ridge">
     <description>The ridge narrows to a sliver of stone barely wide enough to give purchase.  To the west, the cliff drops to a deep chasm, while to the east, the mountain face presses close to the path.  Sharp, loose stones shift and clatter over the edge with every change in the howling wind as it whips across this exposed height.  Upward, the trail continues along the rock.</description>
     <description>Darkness renders the horizon invisible, leaving only the immediate path illuminated by the pale light of the night.  The wind forces its way through the narrow passage with a sharp sound, sending stones tumbling into the abyss below.  The mountain looming to the north silhouettes the sky as a solid wall of shadow.  The edge of the ridge disappears into the absolute black, highlighting the treacherous path and the distance from the ground.</description>
     <position x="120" y="150" z="1" />
@@ -2950,14 +2950,14 @@
     <arc exit="climb" move="climb upward steps" destination="429" />
     <arc exit="climb" move="climb rickety trail" destination="437" />
   </node>
-  <node id="429" name="Undogoz Mountain, Upper Ascent" color="White">
+  <node id="429" name="Undogoz Mountain, Upper Ascent">
     <description>The trail widens as it climbs into a grove of ancient, stunted conifers.  Their needles are dark and waxy, scenting the thin, freezing air with sharp resin.  Through gaps in the gnarled branches, the world below stretches out in a panoramic view.  The island of M'Riss lies surrounded by the waters of Belarritaco Bay, and the floating spires of Mer'Kresh drift upon the surface.  The ascent remains steep, yet the path feels less treacherous than the ridge below.</description>
     <description>The thick canopy of trees at this height cast dense, dark shadows across the path.  The air is still and biting cold.  Below, the bay is a void, punctured by the scattered lights of Mer'Kresh.  The forests of M'Riss appears as a single dark mass surrounded by the shimmer of the Belarritaco Bay.  The opaque silhouette of the mountain's concave peak stretches across the horizon.  The forest is silent, save for the movement of branches in the night air.</description>
     <position x="120" y="140" z="1" />
     <arc exit="climb" move="climb downward steps" destination="428" />
     <arc exit="climb" move="climb rickety trail" destination="430" />
   </node>
-  <node id="430" name="Undogoz Mountain, Western Rim Gully" note="dengizen drake" color="White">
+  <node id="430" name="Undogoz Mountain, Western Rim Gully" note="dengizen drake">
     <description>The trail climbs clockwise along the lip of the great caldera, where the rock turns to brittle, soot-stained obsidian.  Massive nests woven from iron-hard branches and scavenged bones cling to the jagged crags overlooking the burning depths below.  Steam hisses from vents hidden in the stone, clouding the air with a faint sulfuric tang.  Sunlight glints off white eggshells discarded near the path, some broken and others hollow.  The steep drop below is obscured by rolling, grey mist.</description>
     <description>The caldera rim radiates a faint heat that rises from the darkened pit, carrying the smell of earth.  The limited light strikes the nests, making the tangled sticks and bones appear as heaps of debris.  A cold, sulfurous wind tears through the crags.  Shadows move within the nests as the wind shifts, creating an illusion of movement.  The air tastes of metallic dust and dying fire.</description>
     <position x="100" y="140" z="1" />
@@ -2965,7 +2965,7 @@
     <arc exit="northwest" move="northwest" destination="432" />
     <arc exit="climb" move="climb rickety trail" destination="429" />
   </node>
-  <node id="431" name="Undogoz Mountain, Western Rim Gully" color="White">
+  <node id="431" name="Undogoz Mountain, Western Rim Gully">
     <description>The gully narrows into a steep V-shape where the rock walls rise like serrated teeth.  Deep gouges mar the basalt, each furrow wide enough to suggest the passage of a massive claw.  A thick, pungent musk hangs in the stagnant air, clinging to the damp crevices.  Sunlight barely reaches the floor of the passage, leaving the stone slick with condensation.  Small piles of shed, leathery fragments lie tucked against the base of the eastern wall.</description>
     <description>Total darkness fills the gully, turning the jagged walls into looming silhouettes.  The air grows cold and sharp, biting at the skin.  Sounds of shifting rock echo from the depths, suggesting movement in the pitch black.  The light of the night sky fails to penetrate the narrow opening above, leaving the floor as an ink-black void.  The scent of ozone and wet reptile scales drifts on the breeze.</description>
     <position x="80" y="140" z="1" />
@@ -2974,7 +2974,7 @@
     <arc exit="northwest" move="northwest" destination="433" />
     <arc exit="go" move="go gully hollow" destination="435" />
   </node>
-  <node id="432" name="Undogoz Mountain, Western Rim Gully" color="White">
+  <node id="432" name="Undogoz Mountain, Western Rim Gully">
     <description>A wide, flat shelf of granite provides a foundation for several sprawling nests of gnarled ironwood and the white, bleached skulls of mountain goats.  Thick layers of ash cover every surface, muffling the sound of movement like a heavy blanket.  Sunlight is filtered through a constant haze of floating dust, casting a pale and sickly light across the nesting grounds.  The air is stagnant and carries the faint, dry scent of ancient cinders.</description>
     <description>Limited light filters through a veil of lingering dust.  The ash-covered shelf becomes a landscape of soft, grey mounds that hide the jagged edges of the stone beneath.  Shadows within the bone-strewn nests move as the wind shifts the fine powder.  A deep, palpable silence settles over the heights.  The cold air holds the taste of mineral grit and the musk of predators.</description>
     <position x="80" y="120" z="1" />
@@ -2983,7 +2983,7 @@
     <arc exit="west" move="west" destination="433" />
     <arc exit="northwest" move="northwest" destination="434" />
   </node>
-  <node id="433" name="Undogoz Mountain, Western Rim Gully" color="White">
+  <node id="433" name="Undogoz Mountain, Western Rim Gully">
     <description>The trail narrows to a spine of dark granite that connects two high points on the caldera rim.  Thousands of parallel gouges mark the stone where large winged predators have made their home.  A single nest is tucked into a depression at the center of the ridge, surrounded by a ring of upright obsidian shards.  Sunlight creates a shimmering heat haze that rises from the dark rock.  To the northeast, the caldera depth is visible.</description>
     <description>The granite ridge obscures much of the ambient lighting of the night, remaining a dark and treacherous path across the heights.  The obsidian shards catch slivers of light that do reach into this gully, standing like frozen black flames around the central nest.  A freezing draft pulls across the mountain spine, carrying the scent of snow and sulfur.  The gouges in the stone look like deep, dark scars in the silver light.</description>
     <position x="60" y="120" z="1" />
@@ -2992,28 +2992,28 @@
     <arc exit="southeast" move="southeast" destination="431" />
     <arc exit="go" move="go gully hollow" destination="436" />
   </node>
-  <node id="434" name="Undogoz Mountain, Western Rim Gully" color="White">
+  <node id="434" name="Undogoz Mountain, Western Rim Gully">
     <description>The trail descends into a natural flume where the walls consist of raw, razor-edged obsidian.  Jagged glass protrusions jut from the stone, forming natural shelves for a series of small nests.  Sunlight strikes the black surfaces and creates a blinding glare that obscures the path ahead.  The ground is covered in a layer of fine, dark sand, and the air is stagnant and smells of dry minerals and scorched earth.</description>
     <description>The obsidian walls of this gully obscure almost all the lingering light, leaving only a narrow strip of ambient light between the rock formations.  Only the sharpest edges of collected glass catch the silver glow, appearing as thin lines of light in the darkness.  Silent, dark hollows create natural nesting locations tucked into the stone.  A cold breeze pulls through the passage, rattling the loose obsidian flakes against the floor.</description>
     <position x="60" y="100" z="1" />
     <arc exit="southeast" move="southeast" destination="432" />
     <arc exit="south" move="south" destination="433" />
   </node>
-  <node id="435" name="Undogoz Mountain, Ascent Hollow" color="White">
+  <node id="435" name="Undogoz Mountain, Ascent Hollow">
     <description>A vast, circular chamber opens into the heart of the ridge.  Massive nests made of woven timber and bleached bone dominate the space.  Through the high fissure in the western wall, the Reshal Sea glimmers.  The air is warm and stagnant, carrying the scent of dry rot.  Large, hollow fragments of eggshells sit among the debris, their surfaces marked by sharp, irregular cracks.  The ceiling rises to a dark, jagged peak.</description>
     <description>The night's dim light enters through the high fissure, highlighting the tangled mess of the nests.  The skeletal remains of the structures stand out against the deep shadow of the cavern.  A low, rhythmic sound vibrates through the stone, echoing the distant surge of the sea.  The darkness feels heavy, pressing against the skin.</description>
     <position x="60" y="140" z="1" />
     <arc exit="northwest" move="northwest" destination="436" />
     <arc exit="up" move="up" destination="431" />
   </node>
-  <node id="436" name="Undogoz Mountain, Ascent Hollow" color="White">
+  <node id="436" name="Undogoz Mountain, Ascent Hollow">
     <description>The gully constricts into a wide, jagged opening that leads into the mountain.  Sun spills across the threshold and illuminates the scattered ribs and skulls of mountain goats.  To the west, the expansive blue waters of the Reshal Sea stretch to the horizon, visible through the natural arch.  The stone floor is worn smooth by heavy movement.  A thick, dry musk hangs in the air, clinging to the porous basalt walls.</description>
     <description>Light from the night sky above catches the jagged rim of the arch, casting long shadows into the interior.  The Reshal Sea appears as a black expanse below, devoid of light.  The smell of old dust and dried decay rises from the floor.  Each step scrapes against the uneven stone, echoing against the ceiling.  The darkness within the hollow swallows the faint starlight, leaving the path ahead an uncertain void.</description>
     <position x="40" y="120" z="1" />
     <arc exit="southeast" move="southeast" destination="435" />
     <arc exit="out" move="out" destination="433" />
   </node>
-  <node id="437" name="Undogoz Mountain, Eastern Ascent" note="haizen drake" color="White">
+  <node id="437" name="Undogoz Mountain, Eastern Ascent" note="haizen drake">
     <description>Total darkness fills the gully, turning the jagged walls into looming silhouettes.  The air grows cold and sharp, biting at the skin.  Sounds of shifting rock echo from the depths.  The light from the night sky fails to penetrate the narrow opening, leaving the floor as a void.  The lights of the distant city and the bay reflect in the stillness of the night.</description>
     <description>A deep gully cuts into the southeastern granite flank.  High walls of dark stone rise on either side, trapping the scent of heavy, reptilian musk.  Deep gouges mar the cliff face, each furrow wide enough to suggest the passage of a massive claw.  To the east, the ruins of the Old City break the horizon.  The floating spires of Mer'Kresh drift above the crystal-clear waters of Belarritaco Bay in the distance.</description>
     <position x="140" y="150" z="1" />
@@ -3021,7 +3021,7 @@
     <arc exit="east" move="east" destination="439" />
     <arc exit="climb" move="climb rickety trail" destination="428" />
   </node>
-  <node id="438" name="Undogoz Mountain, Eastern Ascent" color="White">
+  <node id="438" name="Undogoz Mountain, Eastern Ascent">
     <description>The night's sky casts light that turns the bone piles into indistinguishable white shapes.  Belarritaco Bay barely reflects the flickering torches lighting the harbor.  Mer'Kresh is a cluster of distant lights.  The air is cold and thin, and shadows move near the wall.</description>
     <description>A flat shelf of granite overlooks the bay.  Piles of bones lie against the rock wall.  To the southeast, Mer'Kresh floats above the water, while the ruins of the Old City are visible to the east.  The bay waters are clear and calm, stretching toward the horizon.  A heavy scent of predator musk sits in the air, thick and persistent.</description>
     <position x="160" y="130" z="1" />
@@ -3029,7 +3029,7 @@
     <arc exit="east" move="east" destination="440" />
     <arc exit="southwest" move="southwest" destination="437" />
   </node>
-  <node id="439" name="Undogoz Mountain, Eastern Ascent" color="White">
+  <node id="439" name="Undogoz Mountain, Eastern Ascent">
     <description>Light cast by the night sky washes the ridge in silver.  The dunes disappear into the black north.  To the east, the city remains a silhouette against the horizon.  The lights of Mer'Kresh twinkle in the distance to the southeast.  The bone nests cast hard, jagged shadows across the path.  Cold wind whistles through the crevices of the gully.</description>
     <description>The eastern gully cuts into the mountain ridge, opening onto a wide panorama.  Barely visible to the north, the Dunes of Despair glimmer.  To the east, the ruins of the city stand.  Further southeast, the structures of Mer'Kresh drift above the waters of the bay.  Scattered nests of bone clutter the rocky floor, their twisted structures anchored into the cliff face.  Scratches mar the stone walls.</description>
     <position x="160" y="150" z="1" />
@@ -3037,7 +3037,7 @@
     <arc exit="west" move="west" destination="437" />
     <arc exit="go" move="go gully hollow" destination="443" />
   </node>
-  <node id="440" name="Undogoz Mountain, Eastern Ascent" color="White">
+  <node id="440" name="Undogoz Mountain, Eastern Ascent">
     <description>Vapor rises from a hollow basin formed from a large recess in the rock floor.  The water of the bay in the distance is black, illuminated only by the reflection of the lights of Mer'Kresh.  Shadows crawl up the walls, revealing movement within the nests formed of fragmented bones.</description>
     <description>Steam drifts from a hollow basin formed by a large recess in the rock floor.  Sunlight reveals the distant bay, where the floating rings of Mer'Kresh catch the light.  The stone walls rise steeply around the basin.  Nests built from fragmented bones cling to the crags above the floor.  The air smells of salt and dry bone.</description>
     <position x="180" y="130" z="1" />
@@ -3046,21 +3046,21 @@
     <arc exit="west" move="west" destination="438" />
     <arc exit="go" move="go gully hollow" destination="442" />
   </node>
-  <node id="441" name="Undogoz Mountain, Eastern Ascent" color="White">
+  <node id="441" name="Undogoz Mountain, Eastern Ascent">
     <description>The granite reflects the night's sky.  The ruins to the eastern horizon are hidden in the darkness.  The lights of Mer'Kresh sparkle across the dark bay.  The wind whistles through the rocks.</description>
     <description>Granite shards cover the ground.  The ruins of the Old City stand in the distance to the east.  The slope drops away toward the water.  The view encompasses the bay and the floating city.  Jagged rocks protrude from the path, creating narrow passages.</description>
     <position x="180" y="110" z="1" />
     <arc exit="south" move="south" destination="440" />
     <arc exit="southwest" move="southwest" destination="438" />
   </node>
-  <node id="442" name="Undogoz Mountain, Eastern Hollow" color="White">
+  <node id="442" name="Undogoz Mountain, Eastern Hollow">
     <description>Ambient light seeps into the hollow and reveals the bone nests as pale, white mounds.  The horizon line blends into the dark water of the bay.  The floating city of Mer'Kresh provides a cluster of distant, flickering lights.  Shadows stretch from the debris and obscure the path.  A cool draft moves through the entrance and carries the faint sound of the sea.</description>
     <description>Nests constructed from bleached bone and scavenged limbs sit against the curved walls.  Through the opening to the east, the crystal-clear waters of Belarritaco Bay span the horizon.  The floating, ringed city of Mer'Kresh drifts on the surface to the southeast.  The air smells of dry bone and sea salt.</description>
     <position x="180" y="150" z="1" />
     <arc exit="southwest" move="southwest" destination="443" />
     <arc exit="out" move="out" destination="440" />
   </node>
-  <node id="443" name="Undogoz Mountain, Eastern Hollow" color="White">
+  <node id="443" name="Undogoz Mountain, Eastern Hollow">
     <description>Ambient light settles on fragments of bone that form nests for unhatched eggs.  Outside this eastern-facing hollow, the island of M'Riss rests in the dark, and the ancient ruins remain visible in the distance.  The Dunes of Despair stretch far to the north.  Wind whistles through the hollow, rattling the remains of wildlife stolen to guard young drakes.  The air smells of stone.</description>
     <description>Through the opening of the hollow, the forests of M'Riss, punctuated by ancient ruins, can be seen.  Nests fashioned from scavenged bone sit on the basalt floor, anchored into the rock.  The golden Dunes of Despair contrast with the green trees to the north.  The air smells of bone and dust.  Light hits the remains of the nests and the stone walls.</description>
     <position x="160" y="170" z="1" />

--- a/Map116_Hibarnhvidar.xml
+++ b/Map116_Hibarnhvidar.xml
@@ -3363,19 +3363,19 @@
     <position x="12" y="98" z="0" />
     <arc exit="go" move="go stone passage" destination="98" />
   </node>
-  <node id="504" name="Cavern of Fire, Rough Tunnel" color="White">
+  <node id="504" name="Cavern of Fire, Rough Tunnel">
     <description>Roughly hacked out walls meet with the unevenly finished floor in this crudely crafted passageway.  A faint odor of smoke mingles with a musky, animal scent.</description>
     <position x="300" y="100" z="2" />
     <arc exit="east" move="east" destination="505" />
     <arc exit="west" move="west" destination="493" />
   </node>
-  <node id="505" name="Cavern of Fire, Rough Tunnel" color="White">
+  <node id="505" name="Cavern of Fire, Rough Tunnel">
     <description>Cut through the stone with a minimum of care and a maximum of haste, the passage burrows deeper into the ground.  On one wall, an opening into a natural cavern shows where the excavators intersected with a pre-existing grotto.</description>
     <position x="320" y="100" z="2" />
     <arc exit="west" move="west" destination="504" />
     <arc exit="go" move="go cavern opening" destination="506" />
   </node>
-  <node id="506" name="Cavern of Fire, Limestone Cave" color="White">
+  <node id="506" name="Cavern of Fire, Limestone Cave">
     <description>Limestone walls enclose this naturally formed grotto deep underground.  Through the opening, a crudely hacked out tunnel can be glimpsed.</description>
     <position x="340" y="100" z="2" />
     <arc exit="southeast" move="southeast" destination="511" />
@@ -3383,7 +3383,7 @@
     <arc exit="southwest" move="southwest" destination="509" />
     <arc exit="go" move="go cavern opening" destination="505" />
   </node>
-  <node id="507" name="Cavern of Fire, Near a Pool" color="White">
+  <node id="507" name="Cavern of Fire, Near a Pool">
     <description>Occasionally disturbed by a drip from one of the stalactites overhead, the still waters of the pool are dark and deep.  Flowstone covers much of the floor, the product of many years of deposited sediments forming into wavy formations.</description>
     <position x="340" y="120" z="2" />
     <arc exit="north" move="north" destination="506" />
@@ -3392,7 +3392,7 @@
     <arc exit="southwest" move="southwest" destination="510" />
     <arc exit="west" move="west" destination="509" />
   </node>
-  <node id="508" name="Cavern of Fire, Limestone Cave" color="White">
+  <node id="508" name="Cavern of Fire, Limestone Cave">
     <description>Stalactites thrust up from the ground, some almost touching the stalagmites reaching down from the ceiling.  A faint musky scent hints of the animals that make this cavern their home.</description>
     <position x="340" y="140" z="2" />
     <arc exit="north" move="north" destination="507" />
@@ -3400,7 +3400,7 @@
     <arc exit="west" move="west" destination="510" />
     <arc exit="northwest" move="northwest" destination="509" />
   </node>
-  <node id="509" name="Cavern of Fire, Limestone Cave" color="White">
+  <node id="509" name="Cavern of Fire, Limestone Cave">
     <description>Periodically, a gentle *drip*drip*drip* echoes through the area from somewhere else in the cavern.  Overhead, bats dart and zip about as they flit through the space.</description>
     <position x="320" y="120" z="2" />
     <arc exit="northeast" move="northeast" destination="506" />
@@ -3408,14 +3408,14 @@
     <arc exit="southeast" move="southeast" destination="508" />
     <arc exit="south" move="south" destination="510" />
   </node>
-  <node id="510" name="Cavern of Fire, Limestone Cave" color="White">
+  <node id="510" name="Cavern of Fire, Limestone Cave">
     <description>Piles of bones lie in irregular stacks in the corners of the cavern.  Each mound is jumbled up with other debris and rotting bits of meat and other noxious matter.</description>
     <position x="320" y="140" z="2" />
     <arc exit="north" move="north" destination="509" />
     <arc exit="northeast" move="northeast" destination="507" />
     <arc exit="east" move="east" destination="508" />
   </node>
-  <node id="511" name="Cavern of Fire, Limestone Cave" color="White">
+  <node id="511" name="Cavern of Fire, Limestone Cave">
     <description>Water seeps from the walls, collecting into a tiny pool before snaking across the floor in a tiny rivlet and disappearing deeper in the cavern.</description>
     <position x="360" y="120" z="2" />
     <arc exit="southwest" move="southwest" destination="508" />
@@ -3423,13 +3423,13 @@
     <arc exit="northwest" move="northwest" destination="506" />
     <arc exit="go" move="go cave opening" destination="512" />
   </node>
-  <node id="512" name="Cavern of Fire, Secluded Alcove" color="White">
+  <node id="512" name="Cavern of Fire, Secluded Alcove">
     <description>Opening up from the narrow entrance, the stone walls enclose a small area devoid of any cavern features such as stalagtites or pools.  Smooth walls arch overhead to form a vaulted roof.</description>
     <position x="380" y="140" z="2" />
     <arc exit="northeast" move="northeast" destination="513" />
     <arc exit="go" move="go cave opening" destination="511" />
   </node>
-  <node id="513" name="Cavern of Fire, Hidden Alcove" color="White">
+  <node id="513" name="Cavern of Fire, Hidden Alcove">
     <description>Four large gashes mar one wall, each one parallel to the others and gouged deep into the limestone walls.  Broken bits of bone and rotting meat lie in small piles scattered across the floor, adding a pungent aroma to the room.</description>
     <position x="400" y="120" z="2" />
     <arc exit="southwest" move="southwest" destination="512" />

--- a/Map116_Hibarnhvidar.xml
+++ b/Map116_Hibarnhvidar.xml
@@ -3085,7 +3085,7 @@
     <arc exit="southeast" move="southeast" destination="459" />
     <arc exit="southwest" move="southwest" destination="460" />
   </node>
-  <node id="459" name="Hibarnhvidar Alchemy Society, Books" note="Alchemy Books" color="Red">
+  <node id="459" name="Hibarnhvidar Alchemy Society, Books" note="Alchemy Books" color="#FF0000">
     <description>Shelves display books available for purchase while a chart shows techniques.  A clerk notes work order completions on a board.</description>
     <position x="270" y="210" z="1" />
     <arc exit="south" move="south" destination="464" />
@@ -3093,7 +3093,7 @@
     <arc exit="west" move="west" destination="460" />
     <arc exit="northwest" move="northwest" destination="458" />
   </node>
-  <node id="460" name="Hibarnhvidar Alchemy Society, Supplies" note="Alchemy Supplies" color="Red">
+  <node id="460" name="Hibarnhvidar Alchemy Society, Supplies" note="Alchemy Supplies" color="#FF0000">
     <description>Shelves of spices, herbs, and other ingredients line the walls while clerks dart to and fro filling orders for customers.  A long counter allows for the inspection of the various supplies before final purchase.</description>
     <position x="250" y="210" z="1" />
     <arc exit="northeast" move="northeast" destination="458" />
@@ -3124,7 +3124,7 @@
     <arc exit="west" move="west" destination="462" />
     <arc exit="northwest" move="northwest" destination="461" />
   </node>
-  <node id="464" name="Hibarnhvidar Alchemy Society, Tools" note="Alchemy Tools" color="Red">
+  <node id="464" name="Hibarnhvidar Alchemy Society, Tools" note="Alchemy Tools" color="#FF0000">
     <description>Stacks of supply crates line the walls while the counter displays various alchemical tools for sale.  Frazzled-looking clerks help customers with their purchases.</description>
     <position x="270" y="230" z="1" />
     <arc exit="north" move="north" destination="459" />
@@ -3173,17 +3173,17 @@
     <position x="200" y="190" z="1" />
     <arc exit="south" move="south" destination="466" />
   </node>
-  <node id="471" name="Hibarnhvidar Outfitting Society, Supply Emporium" note="Outfitting Supplies" color="Red">
+  <node id="471" name="Hibarnhvidar Outfitting Society, Supply Emporium" note="Outfitting Supplies" color="#FF0000">
     <description>Cubbyholes chiseled from the rock walls display the vast array of fabrics, leathers and other supplies available to members for their projects.  Swatches of some of the textiles and threads are set out on the counter for inspection before purchase.</description>
     <position x="210" y="190" z="1" />
     <arc exit="southwest" move="southwest" destination="466" />
   </node>
-  <node id="472" name="Hibarnhvidar Outfitting Society, Book Emporium" note="Outfitting Books" color="Red">
+  <node id="472" name="Hibarnhvidar Outfitting Society, Book Emporium" note="Outfitting Books" color="#FF0000">
     <description>Racks hold the manuals and booklets available for purchase, allowing the patrons to peruse before taking their selections to the polished stone counter near the door.  A bearded Dwarf stands ready at the counter to assist shoppers with questions or to complete purchases.</description>
     <position x="210" y="200" z="1" />
     <arc exit="west" move="west" destination="466" />
   </node>
-  <node id="473" name="Hibarnhvidar Outfitting Society, Tool Emporium" note="Outfitting Tools" color="Red">
+  <node id="473" name="Hibarnhvidar Outfitting Society, Tool Emporium" note="Outfitting Tools" color="#FF0000">
     <description>Sturdy shelves behind the long wooden counter hold a variety of tools needed by the members of the society, all neatly stored away for easy access.  A burly looking Dwarf stands behind the counter, his beady eyes missing nothing that happens in the chamber.</description>
     <position x="210" y="210" z="1" />
     <arc exit="northwest" move="northwest" destination="466" />
@@ -3206,7 +3206,7 @@
     <position x="83" y="187" z="1" />
     <arc exit="west" move="west" destination="475" />
   </node>
-  <node id="477" name="Hibarnhvidar Engineering Society, Depot" note="Engineering Supplies" color="Red">
+  <node id="477" name="Hibarnhvidar Engineering Society, Depot" note="Engineering Supplies" color="#FF0000">
     <description>Standing in the center of the room is a large semi-circular counter, behind which busy clerks take and fulfill orders for the crafters.  A large crate stands at one end of the counter while a sign hangs on one wall.</description>
     <position x="70" y="200" z="1" />
     <arc exit="north" move="north" destination="475" />
@@ -3231,12 +3231,12 @@
     <position x="70" y="213" z="1" />
     <arc exit="north" move="north" destination="477" />
   </node>
-  <node id="481" name="Hibarnhvidar Engineering Society, Toolstore" note="Engineering Tools" color="Red">
+  <node id="481" name="Hibarnhvidar Engineering Society, Toolstore" note="Engineering Tools" color="#FF0000">
     <description>Tools hang from corkboard decorating this long, rectangular room.  A thick scent of oil clings to the air, and the scraping sound of stone sharpening metal drones on in the background.  Some nearby salespeople wait to help customers.</description>
     <position x="57" y="200" z="1" />
     <arc exit="east" move="east" destination="477" />
   </node>
-  <node id="482" name="Hibarnhvidar Engineering Society, Bookstore" note="Engineering Books" color="Red">
+  <node id="482" name="Hibarnhvidar Engineering Society, Bookstore" note="Engineering Books" color="#FF0000">
     <description>Most of the room is blocked off by a long counter behind which stand tall bookshelves in neat rows.  Busy clerks move between the counter and the shelves, filling orders for the engineers.  An overpowering scent of ink and leather fills the area.</description>
     <position x="57" y="187" z="1" />
     <arc exit="southeast" move="southeast" destination="477" />

--- a/Map14d_Moonmage_Guild.xml
+++ b/Map14d_Moonmage_Guild.xml
@@ -200,7 +200,7 @@
     <arc exit="east" move="east" destination="32" />
     <arc exit="climb" move="climb stair" destination="35" />
   </node>
-  <node id="34" name="Lava Forge, Lobby" color="Red">
+  <node id="34" name="Lava Forge, Lobby" color="#FF0000">
     <description>Dust drifts through the archway over the cooled lava floor and piles in the corners of the stone building.  A bored Human attendant relaxes on a stool near a leather curtain that closes off the rest of the forge.</description>
     <position x="-360" y="-220" z="0" />
     <arc exit="out" move="out" destination="23" />

--- a/Map150_Fang_Cove.xml
+++ b/Map150_Fang_Cove.xml
@@ -1748,7 +1748,7 @@
     <position x="315" y="320" z="0" />
     <arc exit="east" move="east" destination="222" />
   </node>
-  <node id="261" name="Fang's Rise, Secluded Island" color="White">
+  <node id="261" name="Fang's Rise, Secluded Island">
     <description>Low hanging trees, branches and dense vegetation make this little island seem to be like its own secluded world.  The sounds of the nearby waterfall are nearly drowned out by the abundant insects, birds and other creatures hiding within the profuse foliage.  A well-worn tree stump, smooth with age, sits before a large flat rock that appears to have been used as a table.</description>
     <position x="420" y="320" z="0" />
     <arc exit="climb" move="climb low-hanging branch" destination="119" />
@@ -1769,7 +1769,7 @@
     <position x="143" y="330" z="0" />
     <arc exit="go" move="go purpleheart door" destination="88" />
   </node>
-  <node id="265" name="Fang Cove, Verdant Snarl" note="sovamedo" color="White">
+  <node id="265" name="Fang Cove, Verdant Snarl" note="sovamedo">
     <description>Dense undergrowth spreads across the area, a layered tangle of brush, shrubs, and low trees bound together by looping vines and trailing creepers.  Narrow, winding trails cut through the growth in branching paths, their packed surfaces weaving between roots and thickets.  Overhead, interlaced limbs form a broken canopy, partially sheltering the uneven ground.</description>
     <position x="507" y="340" z="0" />
     <arc exit="north" move="north" destination="266" />
@@ -1777,14 +1777,14 @@
     <arc exit="east" move="east" destination="268" />
     <arc exit="climb" move="climb narrow crevice" destination="96" />
   </node>
-  <node id="266" name="Fang Cove, Verdant Snarl" color="White">
+  <node id="266" name="Fang Cove, Verdant Snarl">
     <description>Clusters of shrubs and closely set trees form a continuous thicket, their growth interlaced with trailing vines and creeping stems.  Worn passages curve through the undergrowth, splitting and rejoining as they follow the contours of the land.</description>
     <position x="507" y="320" z="0" />
     <arc exit="east" move="east" destination="267" />
     <arc exit="southeast" move="southeast" destination="268" />
     <arc exit="south" move="south" destination="265" />
   </node>
-  <node id="267" name="Fang Cove, Verdant Snarl" color="White">
+  <node id="267" name="Fang Cove, Verdant Snarl">
     <description>A dense sprawl of brush and low-reaching limbs blankets the area, bound tight with creeping growth.  Slender trails wind through the tangle in intersecting lines, their paths worn smooth where movement has pressed them into the earth.</description>
     <position x="527" y="320" z="0" />
     <arc exit="south" move="south" destination="268" />
@@ -1792,14 +1792,14 @@
     <arc exit="west" move="west" destination="266" />
     <arc exit="climb" move="climb rocky incline" destination="269" />
   </node>
-  <node id="268" name="Fang Cove, Verdant Snarl" color="White">
+  <node id="268" name="Fang Cove, Verdant Snarl">
     <description>Thick growth crowds the area, where tangled shrubs and young trees press close beneath a web of climbing vines.  A network of narrow tracks threads through the brush, bending around dense clusters and dipping between exposed roots.  The ground is uneven, layered with compressed debris.</description>
     <position x="527" y="340" z="0" />
     <arc exit="north" move="north" destination="267" />
     <arc exit="west" move="west" destination="265" />
     <arc exit="northwest" move="northwest" destination="266" />
   </node>
-  <node id="269" name="Fang Cove, Verdant Outcrop" color="White">
+  <node id="269" name="Fang Cove, Verdant Outcrop">
     <description>A broad cave mouth opens beneath a low ceiling of rough stone, the rocky overhang covered in a vibrant green tapestry of leafy vines.  The ground is rocky and uneven, scattered with gnawed bones and loose feathers.  Jagged stone presses down from above, narrowing the space beneath the overhang.</description>
     <position x="547" y="320" z="0" />
     <arc exit="north" move="north" destination="270" />
@@ -1807,21 +1807,21 @@
     <arc exit="east" move="east" destination="272" />
     <arc exit="climb" move="climb rocky incline" destination="267" />
   </node>
-  <node id="270" name="Fang Cove, Verdant Outcrop" color="White">
+  <node id="270" name="Fang Cove, Verdant Outcrop">
     <description>The cave mouth narrows slightly, its low ceiling casting heavy shadows across the uneven floor visible from the entrance.  At the farthest point from the opening, small pairs of yellow eyes blink intermittently, appearing and vanishing within the recesses of the stone.</description>
     <position x="547" y="300" z="0" />
     <arc exit="east" move="east" destination="271" />
     <arc exit="southeast" move="southeast" destination="269" />
     <arc exit="south" move="south" destination="269" />
   </node>
-  <node id="271" name="Fang Cove, Verdant Outcrop" color="White">
+  <node id="271" name="Fang Cove, Verdant Outcrop">
     <description>Rough stone walls curve beneath a low, rocky overhang, forming a shallow chamber decorated with a wall of interwoven vines.  The ground bears many gouges, grouped in parallel slashes, and scattered bones dotted with golden feathers.  Small fragments of teeth and hide collect in shallow depressions along the edges of the chamber.</description>
     <position x="567" y="300" z="0" />
     <arc exit="south" move="south" destination="272" />
     <arc exit="southwest" move="southwest" destination="269" />
     <arc exit="west" move="west" destination="270" />
   </node>
-  <node id="272" name="Fang Cove, Verdant Outcrop" color="White">
+  <node id="272" name="Fang Cove, Verdant Outcrop">
     <description>The low-roofed cavern extends inward beyond your vantage point at the entrance, its ceiling dipping close above a floor worn smooth in places.  Barely visible against the deep gloom at the back of the natural room, the edge of a large nest cradles the cracked remains of a giant egg.</description>
     <position x="567" y="320" z="0" />
     <arc exit="north" move="north" destination="271" />

--- a/Map1_Crossing.xml
+++ b/Map1_Crossing.xml
@@ -6597,7 +6597,7 @@
     <position x="-30" y="26" z="0" />
     <arc exit="go" move="go wooden door" destination="874" />
   </node>
-  <node id="1029" name="Siryn's Courtyard, Intro Terrace" note="Siryn's Courtyard" color="Aqua">
+  <node id="1029" name="Siryn's Courtyard, Intro Terrace" note="Siryn's Courtyard" color="#00FFFF">
     <description>Named in tribute to famed Bard Siryn Mistbringer, this welcoming courtyard is an oasis of peace from the hustle and bustle of Clanthew Boulevard.  Sounds of music and laughter filter in from the Bard's Guild next door, drifting across the thick stone walls that enclose the neighborhood.  A flock of wrens perches under the protection of maple trees that provide shade and shelter with their widespread branches.</description>
     <position x="-26" y="-355" z="0" />
     <arc exit="east" move="east" destination="1032" />
@@ -6605,21 +6605,21 @@
     <arc exit="south" move="south" destination="1030" />
     <arc exit="go" move="go gate" destination="29" />
   </node>
-  <node id="1030" name="Siryn's Courtyard, Chorus Terrace" color="Aqua">
+  <node id="1030" name="Siryn's Courtyard, Chorus Terrace" color="#00FFFF">
     <description>Positioned underneath an enormous cedar tree, a well-stocked bar of polished mahogany is set out to entice visitors to sit and stay.  A collection of wrought-iron tables and chairs are thoughtfully placed around the terrace, perfect for those who wish to linger and enjoy a drink or two either alone or in the company of friends.</description>
     <position x="-26" y="-336" z="0" />
     <arc exit="north" move="north" destination="1029" />
     <arc exit="northeast" move="northeast" destination="1033" />
     <arc exit="east" move="east" destination="1031" />
   </node>
-  <node id="1031" name="Siryn's Courtyard, Outro Terrace" color="Aqua">
+  <node id="1031" name="Siryn's Courtyard, Outro Terrace" color="#00FFFF">
     <description>Tucked away in the southeast corner of the terrace, a lone nightingale perched upon the branch of a basswood tree whistles and trills a sweet song to those passing by.  Charmingly low wrought-iron fencing, crafted into a five-line staff with musical notes, separates each courtyard resident's yard from another.</description>
     <position x="-7" y="-336" z="0" />
     <arc exit="north" move="north" destination="1032" />
     <arc exit="west" move="west" destination="1030" />
     <arc exit="northwest" move="northwest" destination="1033" />
   </node>
-  <node id="1032" name="Siryn's Courtyard, Verse Terrace" color="Aqua">
+  <node id="1032" name="Siryn's Courtyard, Verse Terrace" color="#00FFFF">
     <description>Rosewood trees strung with creamy white seashells and silvery windchimes border the walkway that winds through the various residences in this spacious terrace.  In contrast to the simple austerity of the border, brightly colored tulips and buttercups are planted at each bend of the path, providing splashes of colors to please the eyes.</description>
     <position x="-7" y="-355" z="0" />
     <arc exit="south" move="south" destination="1031" />

--- a/Map30_Riverhaven.xml
+++ b/Map30_Riverhaven.xml
@@ -3581,19 +3581,19 @@
     <position x="380" y="550" z="0" />
     <arc exit="south" move="south" destination="563" />
   </node>
-  <node id="565" name="Riverhaven, Housing Offices" color="White">
+  <node id="565" name="Riverhaven, Housing Offices">
     <description>Through the wooden threshold of the square, the modest-sized chamber exudes a comforting warmth.  The walls, made of sturdy timber beams and planks, are a stark contrast to the cold stone prevalent outside.  Torch sconces are affixed at intervals, though they currently stand empty, hinting at occasional use rather than constant occupation.</description>
     <position x="607" y="733" z="0" />
     <arc exit="north" move="north" destination="567" />
     <arc exit="east" move="east" destination="566" />
     <arc exit="southwest" move="southwest" destination="360" />
   </node>
-  <node id="566" name="Riverhaven, Transfer Office" color="White">
+  <node id="566" name="Riverhaven, Transfer Office">
     <description>Shelves line the walls, filled with scrolls, books, and ledgers, their contents ranging from historical records to maps and financial statements.  In one corner, a small hearth provides warmth during colder months, its flickering flames casting dancing shadows on the wooden surfaces.</description>
     <position x="620" y="733" z="0" />
     <arc exit="west" move="west" destination="565" />
   </node>
-  <node id="567" name="Riverhaven, Permit Office" color="White">
+  <node id="567" name="Riverhaven, Permit Office">
     <description>The space is quite small, yet efficiently organized.  A large wooden desk dominates the center, strewn with maps, parchments, and logbooks.  Clearly, this room serves as a cartographer's den, a place where the intricate details of the surrounding lands are meticulously recorded and stored.</description>
     <position x="607" y="720" z="0" />
     <arc exit="south" move="south" destination="565" />

--- a/Map35a_Throne_City_Thief.xml
+++ b/Map35a_Throne_City_Thief.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <zone name="Throne City Thief" id="35a">
-  <node id="1" name="Drainage Channel" color="Blue">
+  <node id="1" name="Drainage Channel" color="#0000FF">
     <description>Bits of broken cobblestones and pieces of shattered statues redirect the route of a stream of rather dirty water, sending it spiraling in little eddies against the curving sides of the channel.  On the other side of the debris pile, the water resumes its steady course, gaining speed until it hurtles through an opening and into the outside world.</description>
     <position x="420" y="280" z="0" />
     <arc exit="west" move="west" destination="2" />
     <arc exit="go" move="go a gap" destination="8" />
   </node>
-  <node id="2" name="Drainage Channel" color="Blue">
+  <node id="2" name="Drainage Channel" color="#0000FF">
     <description>A dark mildew stain covers the lower half of the wall, indicating precisely where the levels of runoff water rise when forced through this passage by rains or floods.  Only a small river of murky liquid gurgles through currently, sloshing against the stones and joyously creating echoes in the otherwise drab and dreary channel.</description>
     <position x="380" y="280" z="0" />
     <arc exit="east" move="swim east" destination="1" />
     <arc exit="northwest" move="swim northwest" destination="3" />
   </node>
-  <node id="3" name="Drainage Channel" color="Blue">
+  <node id="3" name="Drainage Channel" color="#0000FF">
     <description>Six large pipes protrude from beneath a massive stone dais, each spilling their own gallons of water into the collection basin on the floor.  Somewhere behind, overflow from the Faldesu river must regularly fill ditches and channels, only to have its waters diverted here and away from the streets where a flood would be disastrous.</description>
     <position x="360" y="260" z="0" />
     <arc exit="southeast" move="swim southeast" destination="2" />

--- a/Map40a_Langenfirth_to_Siksraja.xml
+++ b/Map40a_Langenfirth_to_Siksraja.xml
@@ -1416,19 +1416,19 @@
     <arc exit="southwest" move="southwest" destination="214" />
     <arc exit="west" move="west" destination="215" />
   </node>
-  <node id="217" name="Noladet Ala, Submerged Pathway" color="White">
+  <node id="217" name="Noladet Ala, Submerged Pathway">
     <description>Set at regular intervals, a road of wide, flat stones lies barely submerged beneath the lake surface.  Stalactites reach from above, the ceiling fading into darkness.  The light of the shoreline can be seen weakly to the north, a gloomy, mist filled darkness filling the south.</description>
     <position x="-580" y="200" z="0" />
     <arc exit="north" move="north" destination="122" />
     <arc exit="south" move="south" destination="218" />
   </node>
-  <node id="218" name="Noladet Ala, Submerged Pathway" color="White">
+  <node id="218" name="Noladet Ala, Submerged Pathway">
     <description>Gentle waves, no more than ripples, play across the submerged stones.  In the midst of near utter silence, the strange acoustics of the surrounding gloom devour all noise.  Far above, glow worms cast pinpricks of slowly moving blue-green light, and to the south, a billowing wall of gloomy mist obscures the pathway, lit from within with faint flickers of swirled gaethzen light.</description>
     <position x="-580" y="220" z="0" />
     <arc exit="north" move="north" destination="217" />
     <arc exit="go" move="go swirling mist" destination="219" />
   </node>
-  <node id="219" name="Noladet Ala, Island" color="White">
+  <node id="219" name="Noladet Ala, Island">
     <description>A rocky platform emerges from the lake, smoothed by either careful handwork or aeons of steady erosion.  The waters lap silently against the little island, gently swaying almost imperceptibly up and down the gradual slope of the shoreline.  At the center of the island stands a dais, the epicenter of a perfect sphere of churning mists which enclose the space.</description>
     <position x="-580" y="240" z="0" />
     <arc exit="southeast" move="southeast" destination="220" />
@@ -1436,21 +1436,21 @@
     <arc exit="southwest" move="southwest" destination="222" />
     <arc exit="go" move="go submerged pathway" destination="218" />
   </node>
-  <node id="220" name="Noladet Ala, Island" color="White">
+  <node id="220" name="Noladet Ala, Island">
     <description>The smooth shoreline sways slightly more rigorously here, pushed by an easterly current that swirls around the the island.  A mounted gaethzen orb provides a dim illumination, casting a weak light over the island.</description>
     <position x="-560" y="280" z="0" />
     <arc exit="north" move="north" destination="219" />
     <arc exit="west" move="west" destination="222" />
     <arc exit="northwest" move="northwest" destination="221" />
   </node>
-  <node id="221" name="Noladet Ala, Dais" color="White">
+  <node id="221" name="Noladet Ala, Dais">
     <description>At the center of the dais rises a thick column of gypsum encrusted with smoothly polished fluorite and calcite crystals, atop which rests a small, carved, soapstone fox.  Perfectly marking the epicenter of the sphere of churning mists which enclose the space, the figurine surveys the near silent area.</description>
     <position x="-580" y="260" z="0" />
     <arc exit="north" move="north" destination="219" />
     <arc exit="southeast" move="southeast" destination="220" />
     <arc exit="southwest" move="southwest" destination="222" />
   </node>
-  <node id="222" name="Noladet Ala, Island" color="White">
+  <node id="222" name="Noladet Ala, Island">
     <description>A large crack spiders outward from the southwestern portion of the dais, shattered flecks of rock and crystal glistening in the weak light of a gaethzen orb.  At its thickest, the crack sloshes with water, having split the small island open.</description>
     <position x="-600" y="280" z="0" />
     <arc exit="north" move="north" destination="219" />

--- a/Map4a_Tiger_Clan.xml
+++ b/Map4a_Tiger_Clan.xml
@@ -752,14 +752,14 @@
     <position x="220" y="440" z="0" />
     <arc exit="climb" move="climb wooden steps" destination="103" />
   </node>
-  <node id="107" name="Tiger Clan, Oak Tree Loop" note="Oak Tree Loop" color="Aqua">
+  <node id="107" name="Tiger Clan, Oak Tree Loop" note="Oak Tree Loop" color="#00FFFF">
     <description>Glad cries and laughter drift from the nearby yards, the sounds those of happy children engaged in active play.  The pathways between the houses are well-trodden dirt but well-maintained with no potholes or litter.</description>
     <position x="280" y="280" z="0" />
     <arc exit="south" move="south" destination="108" />
     <arc exit="west" move="west" destination="109" />
     <arc exit="go" move="go wooden gate" destination="7" />
   </node>
-  <node id="108" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="108" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>Standing tall in the center of the housing area is an enormous oak tree, its wide branches spreading over the simple streets that circle around it.  Set between two houses is a bench swing hanging from one of the tree's outspread limbs.  Bird calls echo from the sky as they swoop and turn in the air.</description>
     <position x="280" y="300" z="0" />
     <arc exit="north" move="north" destination="107" />
@@ -767,27 +767,27 @@
     <arc exit="southwest" move="southwest" destination="115" />
     <arc exit="northwest" move="northwest" destination="109" />
   </node>
-  <node id="109" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="109" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>Abandoned against a fence, a weathered togball waits for its owner to reclaim it.  Behind the fences, neatly manicured lawns sprinkled with shrubs stretch to the fronts of the neat and tidy houses and cottages of the neighborhood.  A few trees cast welcome shade over the yards.</description>
     <position x="260" y="280" z="0" />
     <arc exit="east" move="east" destination="107" />
     <arc exit="southeast" move="southeast" destination="108" />
     <arc exit="west" move="west" destination="110" />
   </node>
-  <node id="110" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="110" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>A wooden bridge crosses a small stream here, allowing the path to continue on without forcing passersby to get their feet wet.  Someone has trained a climbing rose along the railings of the bridge, its blooms filling the air with their scent in season.</description>
     <position x="240" y="280" z="0" />
     <arc exit="east" move="east" destination="109" />
     <arc exit="southwest" move="southwest" destination="112" />
     <arc exit="west" move="west" destination="111" />
   </node>
-  <node id="111" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="111" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>In contrast to most of the houses in the neighborhood, one here is surrounded by a privet hedge instead of a wooden fence.  Otherwise, it is remarkably similar to the rest of the homes here, well-tended with a well-kept yard.  Hanging from one tree is a board and rope swing that sways slightly with any breeze.</description>
     <position x="220" y="280" z="0" />
     <arc exit="east" move="east" destination="110" />
     <arc exit="south" move="south" destination="112" />
   </node>
-  <node id="112" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="112" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>The sound of barking dogs comes from a nearby back yard as something sets the neighborhood canines off.  Against one yard's fence stands a leaf rake, a pile of leaves next to it testimony to its usefulness.</description>
     <position x="220" y="300" z="0" />
     <arc exit="north" move="north" destination="111" />
@@ -795,27 +795,27 @@
     <arc exit="southeast" move="southeast" destination="114" />
     <arc exit="south" move="south" destination="113" />
   </node>
-  <node id="113" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="113" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>Set back from the pathway, this small cul-de-sac is an oasis of calm and quiet within the bustling neighborhood.  Few signs of children at play are exhibited and no toys lie scattered on the lawns of the well-maintained houses.  Bird feeders hang from the trees, providing a welcome repast for the flights of songbirds that chitter and flit from tree to tree.</description>
     <position x="220" y="320" z="0" />
     <arc exit="north" move="north" destination="112" />
     <arc exit="east" move="east" destination="114" />
   </node>
-  <node id="114" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="114" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>Roots from the central oak tree run under the dirt pathway, a few surfacing at spots to try and trip the unwary traveler.  A child's togball lies abandoned in one yard, while another has a weathered dog house set within a pile of weeds.  The picket fences are sturdy, but coated with fading whitewash that sheds flakes into the streets.</description>
     <position x="240" y="320" z="0" />
     <arc exit="east" move="east" destination="115" />
     <arc exit="west" move="west" destination="113" />
     <arc exit="northwest" move="northwest" destination="112" />
   </node>
-  <node id="115" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="115" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>Leaning against a tree in one yard is a wooden scythe with a steel blade, abandoned in the midst of cutting the lawn.  Other homes along the street stand within their own fenced-in yards, their well-constructed roofs and walls giving a snug and neat appearance to the entire neighborhood.</description>
     <position x="260" y="320" z="0" />
     <arc exit="northeast" move="northeast" destination="108" />
     <arc exit="east" move="east" destination="116" />
     <arc exit="west" move="west" destination="114" />
   </node>
-  <node id="116" name="Tiger Clan, Oak Tree Loop" color="Aqua">
+  <node id="116" name="Tiger Clan, Oak Tree Loop" color="#00FFFF">
     <description>Lush grass lawns run down to the pathways between the houses, many of the yards enclosed within picket fences.  Scattered toys and other children's belongings lie haphazardly on the grass, left behind as their owners move on to other amusements.</description>
     <position x="280" y="320" z="0" />
     <arc exit="north" move="north" destination="108" />

--- a/Map58_Acenamacra_Village.xml
+++ b/Map58_Acenamacra_Village.xml
@@ -328,13 +328,13 @@
     <position x="440" y="-240" z="0" />
     <arc exit="out" move="out" destination="26" />
   </node>
-  <node id="52" name="Blue Fire Cove, Steep Trail" note="shadewing harpy" color="White">
+  <node id="52" name="Blue Fire Cove, Steep Trail" note="shadewing harpy">
     <description>A narrow, steep path winds down the cliffside, its surface uneven with jagged stone and loose gravel.  Sharp rocks jut from the sheer walls on either side, while beneath, the water lies far below, stretching along the base of the cliff.  Sparse tufts of hardy coastal vegetation cling to cracks in the rock.  The trail narrows in places, forcing careful footing as it descends toward the beach.</description>
     <position x="520" y="-340" z="0" />
     <arc exit="southeast" move="southeast" destination="53" />
     <arc exit="climb" move="climb steep trail" destination="31" />
   </node>
-  <node id="53" name="Blue Fire Cove, Sheltered Shore" color="White">
+  <node id="53" name="Blue Fire Cove, Sheltered Shore">
     <description>A narrow strip of sand curves beneath the stone overhang, its surface scattered with smooth pebbles and pale driftwood.  The rocky ceiling arches low in places, shaped by years of falling spray.  Channels carved into the sand suggest the steady pull of the tide, while dark pools gather near the cliff base, their edges ringed with mossy stone.</description>
     <position x="540" y="-320" z="0" />
     <arc exit="east" move="east" destination="55" />
@@ -342,19 +342,19 @@
     <arc exit="south" move="south" destination="54" />
     <arc exit="northwest" move="northwest" destination="52" />
   </node>
-  <node id="54" name="Blue Fire Cove, Overhang Hollow" color="White">
+  <node id="54" name="Blue Fire Cove, Overhang Hollow">
     <description>A recessed alcove rests beneath a sweeping curve of stone, its walls streaked with muted blue-grey mineral deposits that form natural patterns.  Loose sand gathers near the back where the rock bends inward, mingling with scattered feathers and faint claw marks that suggest frequent winged visitors.</description>
     <position x="540" y="-300" z="0" />
     <arc exit="north" move="north" destination="53" />
     <arc exit="east" move="east" destination="56" />
   </node>
-  <node id="55" name="Blue Fire Cove, Tide-Carved Ledge" color="White">
+  <node id="55" name="Blue Fire Cove, Tide-Carved Ledge">
     <description>A flat shelf of rock hugs the lagoon's inner rim, worn by centuries of water grinding against its edge.  Pitted surfaces reveal pockets of trapped shells, and shallow grooves run parallel to the shoreline.  The ledge rises only a few feet above the beach, yet offers a clear view of the cove's circular basin and its sheltered waters.</description>
     <position x="560" y="-320" z="0" />
     <arc exit="south" move="south" destination="56" />
     <arc exit="west" move="west" destination="53" />
   </node>
-  <node id="56" name="Blue Fire Cove, Lagoon's Heart" color="White">
+  <node id="56" name="Blue Fire Cove, Lagoon's Heart">
     <description>The lagoon forms a shallow pool bordered by rock and packed sand, its water sheltered by the protective cliff walls.  Large boulders break the surface near the center, creating natural stepping stones.  A narrow channel at the far edge connects to the open sea, its rocky mouth partially masked by tangled marine growth clinging to the stone.</description>
     <position x="560" y="-300" z="0" />
     <arc exit="north" move="north" destination="55" />

--- a/Map62_STR2.xml
+++ b/Map62_STR2.xml
@@ -1365,13 +1365,13 @@
     <arc exit="south" move="south" destination="218" />
     <arc exit="west" move="west" destination="215" />
   </node>
-  <node id="220" name="Workshop, Vestibule" color="White">
+  <node id="220" name="Workshop, Vestibule">
     <description>Round pegs stick out from one side wall, set into the weathered planks to provide a place to hang cloaks or aprons.  A cloak, dusty and almost rotted away from age, still hangs forlornly as if waiting for its owner.  Dust covers the floor and settles into the gaps between the floorboards.</description>
     <position x="500" y="60" z="0" />
     <arc exit="east" move="east" destination="221" />
     <arc exit="go" move="go wooden door" destination="186" />
   </node>
-  <node id="221" name="Workroom, Workspace" color="White">
+  <node id="221" name="Workroom, Workspace">
     <description>Open floorspace is ringed by dust-covered equipment, some of it decayed into piles of rotting or rusted parts that are utterly incapable of identification.  Dried leaves mix with the dirt and filth to form a thick layer of detrius on the floors.  A few holes in the roof show where the leaves gained entrance.</description>
     <position x="520" y="60" z="0" />
     <arc exit="north" move="north" destination="222" />
@@ -1381,35 +1381,35 @@
     <arc exit="south" move="south" destination="224" />
     <arc exit="west" move="west" destination="220" />
   </node>
-  <node id="222" name="Workroom, Workspace" color="White">
+  <node id="222" name="Workroom, Workspace">
     <description>Racks containing dusty tools stand against the walls.  A few worktables stand nearby with equipment haphazardly scattered atop them as if abandoned in mid-task.  High overhead, the exposed roof beams provide a staging area for the complex lattice of spiderwebs.</description>
     <position x="520" y="40" z="0" />
     <arc exit="east" move="east" destination="223" />
     <arc exit="southeast" move="southeast" destination="226" />
     <arc exit="south" move="south" destination="221" />
   </node>
-  <node id="223" name="Workroom, Storage" color="White">
+  <node id="223" name="Workroom, Storage">
     <description>Bins and barrels hold the rotting and decaying remains of materials once used in this working area.  A few burlap sacks lie in crumbling heaps against the walls, what they once contained long since decayed away.</description>
     <position x="540" y="40" z="0" />
     <arc exit="south" move="south" destination="226" />
     <arc exit="southwest" move="southwest" destination="221" />
     <arc exit="west" move="west" destination="222" />
   </node>
-  <node id="224" name="Workroom, Storage" color="White">
+  <node id="224" name="Workroom, Storage">
     <description>Once these shelves held parts and materials for use in the workshop, but now they are covered with corroded and crumbling lumps.  The shelving itself shows signs of disrepair, with some uprights leaning dangerously and others appearing ready to buckle at any moment.</description>
     <position x="520" y="80" z="0" />
     <arc exit="north" move="north" destination="221" />
     <arc exit="northeast" move="northeast" destination="226" />
     <arc exit="east" move="east" destination="225" />
   </node>
-  <node id="225" name="Workroom, Workspace" color="White">
+  <node id="225" name="Workroom, Workspace">
     <description>Two sawhorses are set up in the middle of the area, spaced far apart.  A rusting saw leans against one leg, its blade warped and bent from its long wait.  Two lanterns, long since guttered out, hang suspended on chains from the exposed beams overhead.</description>
     <position x="540" y="80" z="0" />
     <arc exit="north" move="north" destination="226" />
     <arc exit="west" move="west" destination="224" />
     <arc exit="northwest" move="northwest" destination="221" />
   </node>
-  <node id="226" name="Workroom, Workspace" color="White">
+  <node id="226" name="Workroom, Workspace">
     <description>Pegs on one wall hold the remains of tools, although a few have lost handles or other parts.  Dangling ropes hang from the roofbeams, their exact purpose long since lost to time.  Dust covers everything in a thick shroud of concealing grime and grit.</description>
     <position x="540" y="60" z="0" />
     <arc exit="north" move="north" destination="223" />

--- a/Map63_Oshu'ehhrsk_Manor.xml
+++ b/Map63_Oshu'ehhrsk_Manor.xml
@@ -730,7 +730,7 @@
     <arc exit="west" move="west" destination="115" />
     <arc exit="go" move="script oshumanor" destination="58" />
   </node>
-  <node id="114" name="Telpengi'hhs Sara'a, Embalming Chamber" color="Lime">
+  <node id="114" name="Telpengi'hhs Sara'a, Embalming Chamber" color="#00FF00">
     <description>With the passage of time comes the decay of those things material, and no exception is granted to the clay jars and pottery lining the shelves in this nook.  Dim lighting from a torch sconce gives birth to flickering shadows behind those jars, as if the containers' crumbling states released souls that, disbelieving their freedom, still linger near their ruined bodies.</description>
     <position x="460" y="140" z="0" />
     <arc exit="west" move="west" destination="113" />

--- a/Map66_STR3.xml
+++ b/Map66_STR3.xml
@@ -5017,7 +5017,7 @@
     <position x="-580" y="-940" z="0" />
     <arc exit="north" move="north" destination="733" />
   </node>
-  <node id="737" name="House of the Silk Strings, Lotus Pond" color="Blue">
+  <node id="737" name="House of the Silk Strings, Lotus Pond" color="#0000FF">
     <description>Snowy white lotus blossoms blanket the emerald water of this placid woodland pond.  A narrow path through the vegetation has been cleared along the shallows of the pool, and various Elothean workers are using the wading space to carefully harvest lotus leaves.</description>
     <description>Lotus blossoms, closed for the night, blanket the surface of the darkened pond.</description>
     <position x="-600" y="-800" z="0" />
@@ -5025,28 +5025,28 @@
     <arc exit="southeast" move="southeast" destination="741" />
     <arc exit="go" move="go shoreline" destination="708" />
   </node>
-  <node id="738" name="House of the Silk Strings, Lotus Pond" color="Blue">
+  <node id="738" name="House of the Silk Strings, Lotus Pond" color="#0000FF">
     <description>The thick layer of soft white lotus blossoms sways gently to the soporific rhythm of the pond's underwater currents.</description>
     <description>Lotus blossoms, closed for the night, blanket the surface of the darkened pond.</description>
     <position x="-580" y="-820" z="0" />
     <arc exit="southeast" move="southeast" destination="739" />
     <arc exit="southwest" move="southwest" destination="737" />
   </node>
-  <node id="739" name="House of the Silk Strings, Lotus Pond" color="Blue">
+  <node id="739" name="House of the Silk Strings, Lotus Pond" color="#0000FF">
     <description>The sea of botanic white that dominates the rest of the pond blends softly into a contrasting bed of lotus blossoms at this quiet end of the pool.  Distinctly colored blooms surround a mossy stone marker rising stoically from the jewel-toned water below.</description>
     <description>Lotus blossoms, closed for the night, blanket the surface of the darkened pond, while a mossy stone marker quietly stands watch in the still water.</description>
     <position x="-560" y="-800" z="0" />
     <arc exit="southwest" move="southwest" destination="741" />
     <arc exit="northwest" move="northwest" destination="738" />
   </node>
-  <node id="741" name="House of the Silk Strings, Lotus Pond" color="Blue">
+  <node id="741" name="House of the Silk Strings, Lotus Pond" color="#0000FF">
     <description>The rich greens of the pond and its aquatic foliage blend with the floral expanse of lotus-white to create a captivating dichromatic gardenscape, occasionally broken by the flash of a goldfish swimming amongst the underwater stalks.</description>
     <description>Lotus blossoms, closed for the night, blanket the surface of the darkened pond.</description>
     <position x="-580" y="-780" z="0" />
     <arc exit="northeast" move="northeast" destination="739" />
     <arc exit="northwest" move="northwest" destination="737" />
   </node>
-  <node id="742" name="" color="Blue">
+  <node id="742" name="" color="#0000FF">
     <description />
     <position x="0" y="0" z="0" />
   </node>

--- a/Map69_Shard_West_Gate.xml
+++ b/Map69_Shard_West_Gate.xml
@@ -4098,44 +4098,44 @@
     <arc exit="southeast" move="southeast" destination="638" />
     <arc exit="west" move="west" destination="634" />
   </node>
-  <node id="640" name="Julge Dolen Zaldeni, Valley" color="White">
+  <node id="640" name="Julge Dolen Zaldeni, Valley">
     <description>Sinuous shapes occasionally flicker through the tall, thick grass as bright-eyed ferrets scour the area for food.  A half-cropped tuft of buffalo grass shades a hole in the ground that leads to the creatures' burrow.</description>
     <position x="-540" y="-23" z="0" />
     <arc exit="southeast" move="southeast" destination="641" />
     <arc exit="west" move="west" destination="642" />
     <arc exit="climb" move="climb sturdy fence" destination="113" />
   </node>
-  <node id="641" name="Julge Dolen Zaldeni, Valley" color="White">
+  <node id="641" name="Julge Dolen Zaldeni, Valley">
     <description>Overhead, the stars seem brighter than on the grasslands, the high valley walls bringing the expanse into focus.  A parliament of owls sometimes wings by, looking for richer lark-hunting on the plains above.</description>
     <position x="-520" y="-3" z="0" />
     <arc exit="northwest" move="northwest" destination="640" />
   </node>
-  <node id="642" name="Julge Dolen Zaldeni, Valley" color="White">
+  <node id="642" name="Julge Dolen Zaldeni, Valley">
     <description>The tough tops of the towering grass have been broken and chewed in places, but the resilient stems persist in growing.  The greenery sways with every breeze.</description>
     <position x="-580" y="-23" z="0" />
     <arc exit="north" move="north" destination="647" />
     <arc exit="east" move="east" destination="640" />
     <arc exit="northwest" move="northwest" destination="643" />
   </node>
-  <node id="643" name="Julge Dolen Zaldeni, Valley" color="White">
+  <node id="643" name="Julge Dolen Zaldeni, Valley">
     <description>The tall grasses are thicker to the east and west, but a faint path is worn northward where large animals have made for the stream.  The air is redolent of lush greenery, and one can almost hear the roots unfurling within the earth as the plants grow.</description>
     <position x="-600" y="-43" z="0" />
     <arc exit="southeast" move="southeast" destination="642" />
     <arc exit="northwest" move="northwest" destination="644" />
   </node>
-  <node id="644" name="Julge Dolen Zaldeni, Stream Bank" color="White">
+  <node id="644" name="Julge Dolen Zaldeni, Stream Bank">
     <description>Closer to the stream, the grass becomes even more lush and stands just a few hands high -- perfect for grazing.  A few vedda trees provide shade and, in times of desperation, food.</description>
     <position x="-620" y="-63" z="0" />
     <arc exit="northeast" move="northeast" destination="645" />
     <arc exit="southeast" move="southeast" destination="643" />
   </node>
-  <node id="645" name="Julge Dolen Zaldeni, Stream Bank" color="White">
+  <node id="645" name="Julge Dolen Zaldeni, Stream Bank">
     <description>Weeping willows stretch their boughs over the water at the stream's head, providing shelter for a small flock of ducks whose nests dot the bank.  A number of rodents also dwell by the trees, receiving shelter from the elements.</description>
     <position x="-580" y="-103" z="0" />
     <arc exit="east" move="east" destination="646" />
     <arc exit="southwest" move="southwest" destination="644" />
   </node>
-  <node id="646" name="Julge Dolen Zaldeni, Stream Bank" color="White">
+  <node id="646" name="Julge Dolen Zaldeni, Stream Bank">
     <description>Red cedar trees cling to the stream bank, surrounded by weeping willows that vie for the water.  The cedars' gnarled roots protrude into the rivulet, both stabilizing the bank and providing a convenient seat.</description>
     <position x="-540" y="-103" z="0" />
     <arc exit="southeast" move="southeast" destination="649" />
@@ -4143,20 +4143,20 @@
     <arc exit="west" move="west" destination="645" />
     <arc exit="climb" move="climb cedar root" destination="650" />
   </node>
-  <node id="647" name="Julge Dolen Zaldeni, Valley" color="White">
+  <node id="647" name="Julge Dolen Zaldeni, Valley">
     <description>A few cedars stretch north toward the water.  Short-bladed grass and some sedges vie for ground cover.  A meadowlark's nest is almost hidden within the grass, its woven roof a patch of brown among the green.</description>
     <position x="-580" y="-63" z="0" />
     <arc exit="northeast" move="northeast" destination="646" />
     <arc exit="east" move="east" destination="648" />
     <arc exit="south" move="south" destination="642" />
   </node>
-  <node id="648" name="Julge Dolen Zaldeni, Valley" color="White">
+  <node id="648" name="Julge Dolen Zaldeni, Valley">
     <description>Southwest, the shorter grass gives way to a taller variety as the valley rolls in a slow dip.  The grass is a thick, cropped carpet here, with divots turned up by the hooves of fast-moving horses.</description>
     <position x="-520" y="-63" z="0" />
     <arc exit="north" move="north" destination="649" />
     <arc exit="west" move="west" destination="647" />
   </node>
-  <node id="649" name="Julge Dolen Zaldeni, Valley" color="White">
+  <node id="649" name="Julge Dolen Zaldeni, Valley">
     <description>Saplings have taken root among the tenacious grass.  The young trees are not faring well -- tufts of hair are caught in the ragged bark where horses have used them as grooming aids.</description>
     <position x="-520" y="-83" z="0" />
     <arc exit="south" move="south" destination="648" />
@@ -4193,32 +4193,32 @@
     <arc exit="west" move="swim west" destination="653" />
     <arc exit="up" move="swim up" destination="652" />
   </node>
-  <node id="655" name="Wyvern Trail, Hidden Canyon" note="tree sloth" color="White">
+  <node id="655" name="Wyvern Trail, Hidden Canyon" note="tree sloth">
     <description>Buried by an enormous pile of rocks, one end of the twisting canyon now allows a somewhat precarious passage in and out.  Massive tree trunks crowd the rest of the gorge, their branches filling the space overhead.</description>
     <position x="680" y="577" z="0" />
     <arc exit="southwest" move="southwest" destination="656" />
     <arc exit="go" move="go jumbled rocks" destination="592" />
   </node>
-  <node id="656" name="Wyvern Trail, Hidden Canyon" color="White">
+  <node id="656" name="Wyvern Trail, Hidden Canyon">
     <description>Carved long ago, the steep sides of the canyon enclose a lush, almost tropical forest.  Trunks topped by verdant growth tower overhead while the sounds of birds and animals echo throughout.</description>
     <position x="660" y="597" z="0" />
     <arc exit="northeast" move="northeast" destination="655" />
     <arc exit="west" move="west" destination="659" />
     <arc exit="northwest" move="northwest" destination="657" />
   </node>
-  <node id="657" name="Wyvern Trail, Hidden Canyon" color="White">
+  <node id="657" name="Wyvern Trail, Hidden Canyon">
     <description>High overhead there is a break in the canopy as one of the forest's titans has fallen, its thick trunk splayed across the ground where it fell.  Saplings and other scrubby plants grow thickly around the giant's remains, each one striving to crowd out the others and reach the sky.</description>
     <position x="640" y="577" z="0" />
     <arc exit="southeast" move="southeast" destination="656" />
     <arc exit="west" move="west" destination="658" />
   </node>
-  <node id="658" name="Wyvern Trail, Hidden Canyon" color="White">
+  <node id="658" name="Wyvern Trail, Hidden Canyon">
     <description>Chirps and cheeps sound overhead as birds flit between the branches.  An occasional drip of moisture falls from above as the muggy air condenses into a liquid drop.</description>
     <position x="620" y="577" z="0" />
     <arc exit="east" move="east" destination="657" />
     <arc exit="south" move="south" destination="659" />
   </node>
-  <node id="659" name="Wyvern Trail, Hidden Canyon" color="White">
+  <node id="659" name="Wyvern Trail, Hidden Canyon">
     <description>Little grows on the forest floor as most sunlight is blocked by the towering canopy overhead.  A few scraggly bushes struggle for life amongst the leaf litter while the trunks of the colossal trunks host mosses and lichens that grow profusely in the damp climate.</description>
     <position x="620" y="597" z="0" />
     <arc exit="north" move="north" destination="658" />

--- a/Map8_Crossing_East_Gate.xml
+++ b/Map8_Crossing_East_Gate.xml
@@ -189,21 +189,21 @@
     <arc exit="go" move="go ivory door" destination="54" />
     <arc exit="west" move="west" destination="161" />
   </node>
-  <node id="30" name="Middens, Urrem's Bane" color="Aqua">
+  <node id="30" name="Middens, Urrem's Bane" color="#00FFFF">
     <description>Mildewed tangles of rope and precarious footbridges constructed of rotting wood straddle wooden platforms crowded with rickety shacks.  Stunted trees draped with long tendrils of moss shade a small cluster of buildings surrounding a thick cedar that squats in the center of the muck.</description>
     <position x="438" y="66" z="0" />
     <arc exit="north" move="north" destination="21" />
     <arc exit="east" move="east" destination="34" />
     <arc exit="southwest" move="southwest" destination="31" />
   </node>
-  <node id="31" name="Middens, Urrem's Bane" color="Aqua">
+  <node id="31" name="Middens, Urrem's Bane" color="#00FFFF">
     <description>A stack of barrels half-sunk in the thick mud supports the center of a long plank leading from the edge of the deck to a ramshackle building nestled in the twisted branches of a stout cedar.  Taller trees hung with tattered shrouds of moss cast a dark pall over a huddle of tiny homes surrounding the cedar, which stands in the middle like the hub of a broken wagon wheel.</description>
     <position x="418" y="86" z="0" />
     <arc exit="northeast" move="northeast" destination="30" />
     <arc exit="southeast" move="southeast" destination="32" />
     <arc exit="go" move="go plank" destination="87" />
   </node>
-  <node id="32" name="Middens, Urrem's Bane" color="Aqua">
+  <node id="32" name="Middens, Urrem's Bane" color="#00FFFF">
     <description>An ash heap behind the platform diminishes with each breeze, creating sooty clouds that hang in the humid air and tarnish everything a dull grey.  Pale light filters down through the moss-draped canopy and dances over the stolid forms of the small community.</description>
     <position x="438" y="106" z="0" />
     <arc exit="east" move="east" destination="33" />
@@ -215,13 +215,13 @@
     <arc exit="west" move="west" destination="32" />
     <arc exit="go" move="go rope bridge" destination="35" />
   </node>
-  <node id="34" name="Middens, Urrem's Bane" color="Aqua">
+  <node id="34" name="Middens, Urrem's Bane" color="#00FFFF">
     <description>Tall wiregrass crackles in the occasional breeze and scratches the edges of the wooden footbridges, sounding like the scrabbling of thick-carapaced insects.  A trash pile nested in the high grass behind the rickety wooden platform fragrances the air with the sour smell of decay.</description>
     <position x="458" y="66" z="0" />
     <arc exit="southeast" move="southeast" destination="35" />
     <arc exit="west" move="west" destination="30" />
   </node>
-  <node id="35" name="Middens, Urrem's Bane" color="Aqua">
+  <node id="35" name="Middens, Urrem's Bane" color="#00FFFF">
     <description>Sinuous tendrils of dark shadow reach across the muck, pulling at the damp and splintered boards underfoot.  Sheets of hammered tin and uneven scraps of wood held together with rusting nails and frayed bits of rope huddle together in the limited space, looking like card houses ready to blow over at the slightest breeze.  A small rope bridge leads up to another ramshackle platform.</description>
     <position x="478" y="86" z="0" />
     <arc exit="northwest" move="northwest" destination="34" />
@@ -247,7 +247,7 @@
     <arc exit="go" move="go thick plank" destination="88" />
     <arc exit="go" move="go breached wall" destination="106" />
   </node>
-  <node id="39" name="Middens, Zehila" note="Zehila" color="Aqua">
+  <node id="39" name="Middens, Zehila" note="Zehila" color="#00FFFF">
     <description>This is the entrance to the most upscale of the squatters' quarters of the Middens, known as Zehila.  The inhabitants, all S'kra Mur, remain somewhat aloof from the other squatters' colonies, maintaining the pretense of social superiority.  When they do mix with the other downtrodden races of this area, at the Middens' only well, they pass through the junction here with purposeful haste.</description>
     <description>This is the entrance to the most upscale of the squatters' quarters of the Middens, known as Zehila.  The inhabitants, all S'Kra Mur, remain somewhat aloof from the other squatters' colonies, maintaining the pretense of social superiority.  When they do mix with the other downtrodden races of this area, at the Middens' only well, they pass through the junction here with purposeful haste.</description>
     <position x="220" y="46" z="0" />
@@ -261,12 +261,12 @@
     <arc exit="south" move="south" destination="41" />
     <arc exit="northwest" move="northwest" destination="39" />
   </node>
-  <node id="41" name="Middens, Zehila" color="Aqua">
+  <node id="41" name="Middens, Zehila" color="#00FFFF">
     <description>Several women are gathered around a large wooden tub in this dead-end street.  They are chatting in the hissing slang of the S'Kra Mur, their sibilant giggles punctuated by splashes of water as they wash their clothes at this communal laundry.  Long, white robes hang from ropes attempting to dry in the damp air, and a toddler stares at you shyly from behind one.</description>
     <position x="240" y="86" z="0" />
     <arc exit="north" move="north" destination="40" />
   </node>
-  <node id="42" name="Middens, Zehila" color="Aqua">
+  <node id="42" name="Middens, Zehila" color="#00FFFF">
     <description>A small clay statue stands in the corner of this tidy cul-de-sac.  Flowers and unfired clay vessels laden with fruit are set neatly before it.  An old S'Kra Mur, steadying himself with a tall staff, looks startled by your approach.</description>
     <position x="200" y="66" z="0" />
     <arc exit="northeast" move="northeast" destination="39" />

--- a/Map92_Ratha_NW.xml
+++ b/Map92_Ratha_NW.xml
@@ -2174,64 +2174,64 @@
     <arc exit="southwest" move="southwest" destination="303" />
     <arc exit="go" move="go fumarole opening" destination="305" />
   </node>
-  <node id="305" name="Pivilho Volcano, Fumarole Passage" color="White">
+  <node id="305" name="Pivilho Volcano, Fumarole Passage">
     <description>Sulfur crystals encrust the walls, shattered and scraped bare in places by deep claw marks.  The passage extends into the volcano at a modest downward angle, illuminated by a red glow.</description>
     <position x="-20" y="-580" z="0" />
     <arc exit="northwest" move="northwest" destination="306" />
     <arc exit="go" move="go fumarole opening" destination="304" />
   </node>
-  <node id="306" name="Pivilho Volcano, Borehole Overlook" color="White">
+  <node id="306" name="Pivilho Volcano, Borehole Overlook">
     <description>Opening onto a glowing red abyss, a wide bell-like expansion stretches down into the depths.  Hot, dry, stinging air roars upward, a howling updraft that whistles along the walls and across the edge.  Riveted into the ground, a thick steelsilk rope allows for an easy descent to the chamber floor below.</description>
     <position x="-40" y="-600" z="0" />
     <arc exit="southeast" move="southeast" destination="305" />
     <arc exit="climb" move="climb steelsilk rope" destination="307" />
   </node>
-  <node id="307" name="Pivilho Volcano, Hav'roth's Bridge" color="White">
+  <node id="307" name="Pivilho Volcano, Hav'roth's Bridge">
     <description>The wide causeway extends as a large semi-circle across the magma, the rippled, black stone curving gently between the north and south chambers.  To the north, billowing clouds of choking gas swirl malevolently with ash and streaking embers, the ground cracked and glowing red as magma flows beneath barely cooled crust.  To the south, a mournful melody echoes along the walls, the chamber darker and cooler.</description>
     <position x="-60" y="-620" z="0" />
     <arc exit="north" move="north" destination="309" />
     <arc exit="south" move="south" destination="308" />
     <arc exit="climb" move="climb steelsilk rope" destination="306" />
   </node>
-  <node id="308" name="Pivilho Volcano, Peri'el's Calm" color="White">
+  <node id="308" name="Pivilho Volcano, Peri'el's Calm">
     <description>The air is merely warm here, the tortuous heat diffusing harmlessly.  Jingling bells tinkle in the distance, a melody muffling the chaos to the north.  The dark banded rocks of the ground twist and kink, metallic inclusions glimmering in the faint light.  The walls and ceiling waver slightly.</description>
     <position x="-60" y="-600" z="0" />
     <arc exit="north" move="north" destination="307" />
     <arc exit="southeast" move="southeast" destination="313" />
     <arc exit="southwest" move="southwest" destination="312" />
   </node>
-  <node id="309" name="Pivilho Volcano, Ushnish's Rage" color="White">
+  <node id="309" name="Pivilho Volcano, Ushnish's Rage">
     <description>Howling winds blast all around, and crevices burst with yellow hot liquid stone.  Cooling bubbles fade to black, illuminated softly from within with a dull red, occasionally blistering and pushing forward slightly, hissing in a sibilant rumble as the ground shifts in a precarious and mesmerizing flow.  Visibility is limited as hot embers and ash swirl chaotically.</description>
     <position x="-60" y="-640" z="0" />
     <arc exit="northeast" move="northeast" destination="311" />
     <arc exit="south" move="south" destination="307" />
     <arc exit="northwest" move="northwest" destination="310" />
   </node>
-  <node id="310" name="Pivilho Volcano, Ushnish's Rage" color="White">
+  <node id="310" name="Pivilho Volcano, Ushnish's Rage">
     <description>A large pit opens here, billowing lava welling upward, cooling as it hits the air to form a thin skin of stone that shifts with the undercurrent.  Crackling as it moves, the stone skin exposes lines of brighter red magma, jagged and constantly in motion.  Searingly hot air roars around chaotically, thick with noxious fumes.  The walls glisten with metal and gem formations.</description>
     <position x="-80" y="-660" z="0" />
     <arc exit="east" move="east" destination="311" />
     <arc exit="southeast" move="southeast" destination="309" />
   </node>
-  <node id="311" name="Pivilho Volcano, Ushnish's Rage" color="White">
+  <node id="311" name="Pivilho Volcano, Ushnish's Rage">
     <description>Several hollowed out boulders rise slightly from the ground, smoking and glowing with heat, but absent of the ever present magma.  Thick rock scales line the inside of the boulders, piled carefully around several egg-shaped black stones.  From deep within the swirling clouds and murky shadows echoes an angry hiss.</description>
     <position x="-40" y="-660" z="0" />
     <arc exit="southwest" move="southwest" destination="309" />
     <arc exit="west" move="west" destination="310" />
   </node>
-  <node id="312" name="Pivilho Volcano, Peri'el's Calm" color="White">
+  <node id="312" name="Pivilho Volcano, Peri'el's Calm">
     <description>The ground is littered with blackened seashells and the area resounds with an oceanic hissing, reminiscent of the surf.  As the volcano's cacophonous sounds vie for attention, something akin to soft vocals pierce the din, but its source remains elusive.  Glimmering deep within the vaguely transparent banded walls, gemstones flicker with luminescence.</description>
     <position x="-80" y="-580" z="0" />
     <arc exit="northeast" move="northeast" destination="308" />
     <arc exit="east" move="east" destination="313" />
   </node>
-  <node id="313" name="Pivilho Volcano, Peri'el's Calm" color="White">
+  <node id="313" name="Pivilho Volcano, Peri'el's Calm">
     <description>Striations of reds, yellows, lavenders, and blacks ripple along the floor, wall and ceiling, seeming to ebb and flow in the faint light.  Wafting through the area, a cool breeze gently carries a soft, soothing song.  A long, scorched gouge mars the wall, and a ragged chunk of stone is torn free.</description>
     <position x="-40" y="-580" z="0" />
     <arc exit="west" move="west" destination="312" />
     <arc exit="northwest" move="northwest" destination="308" />
   </node>
-  <node id="314" name="Pivilho Volcano, Ember Aerie Pathway" note="cindering harpy" color="White">
+  <node id="314" name="Pivilho Volcano, Ember Aerie Pathway" note="cindering harpy">
     <description>A narrow crevice winds through the volcanic cliffside, forming a steep, narrow path that descends to a rocky shelf.  Loose pebbles and ash coat the ground, while tufts of hardy grass cling to cracks in the weathered stone.  The distant rumble of waves crashing below mixes with the constant whistling of the coastal breeze.</description>
     <position x="-60" y="-475" z="0" />
     <arc exit="west" move="west" destination="315" />
@@ -2239,7 +2239,7 @@
     <arc exit="down" move="down" destination="317" />
     <arc exit="go" move="go narrow path" destination="299" />
   </node>
-  <node id="315" name="Pivilho Volcano, Ember Aerie Grotto" color="White">
+  <node id="315" name="Pivilho Volcano, Ember Aerie Grotto">
     <description>Partially obscured by a curtain of lichen drapery, this small grotto is protected from the wind by dark, porous walls of stone.  Faint, glowing embers are scattered along the floor, evidence of a recent cookfire.  Shallow alcoves carved into the stone on one side hold various tools and trinkets, while a roughly hewn table with cut logs for seats takes up the other.</description>
     <position x="-80" y="-475" z="0" />
     <arc exit="east" move="east" destination="314" />
@@ -2247,35 +2247,35 @@
     <arc exit="down" move="down" destination="318" />
     <arc exit="go" move="go stone steps" destination="320" />
   </node>
-  <node id="316" name="Pivilho Volcano, Ember Aerie Ledge" color="White">
+  <node id="316" name="Pivilho Volcano, Ember Aerie Ledge">
     <description>A wide, rocky shelf stretches out along the cliff, its surface uneven and pitted from erosion.  Sparse vegetation clings to the edges, offering small splashes of green and flax against the dark volcanic stone.  The sound of distant waves echoes from below, occasionally muffled by the wind.</description>
     <position x="-40" y="-460" z="0" />
     <arc exit="southwest" move="southwest" destination="318" />
     <arc exit="west" move="west" destination="319" />
     <arc exit="down" move="down" destination="314" />
   </node>
-  <node id="317" name="Pivilho Volcano, Ember Aerie Ledge" color="White">
+  <node id="317" name="Pivilho Volcano, Ember Aerie Ledge">
     <description>The narrow ledge is partially enclosed by jagged rock formations, offering some protection from the wind.  Ash and dust cover the ground, disturbed only by the occasional footprints.  The cliffs below drop steeply into the ocean, the waves crashing far below.</description>
     <position x="-40" y="-440" z="0" />
     <arc exit="west" move="west" destination="318" />
     <arc exit="northwest" move="northwest" destination="319" />
     <arc exit="up" move="up" destination="314" />
   </node>
-  <node id="318" name="Pivilho Volcano, Ember Aerie Rookery" color="White">
+  <node id="318" name="Pivilho Volcano, Ember Aerie Rookery">
     <description>A nearly vertical cliff stretches below this rocky ledge, the steep slope pockmarked where the ground fell below to the rock-strewn beach.  Small structures made of scavenged timber and sea-worn stone are tucked along the narrow path, nestled into sheltered nooks, with intricately carved doors elevated too high for wingless visitors to enter without assistance.</description>
     <position x="-60" y="-440" z="0" />
     <arc exit="northeast" move="northeast" destination="316" />
     <arc exit="east" move="east" destination="317" />
     <arc exit="up" move="up" destination="315" />
   </node>
-  <node id="319" name="Pivilho Volcano, Ember Aerie Ledge" color="White">
+  <node id="319" name="Pivilho Volcano, Ember Aerie Ledge">
     <description>The ground here is uneven and sloped, littered with broken pieces of volcanic rock in various sizes.  Dark streaks of ash mark the path, while occasional patches of brittle grass grow among the stones.  A few scattered feathers are caught in the cracks, gently shifting with the breeze, their dark tips streaked with hints of scarlet.</description>
     <position x="-60" y="-460" z="0" />
     <arc exit="east" move="east" destination="316" />
     <arc exit="southeast" move="southeast" destination="317" />
     <arc exit="down" move="down" destination="315" />
   </node>
-  <node id="320" name="Pivilho Volcano, Ember Aerie Cliffs" color="White">
+  <node id="320" name="Pivilho Volcano, Ember Aerie Cliffs">
     <description>The ledge slopes gently toward the sea, faraway waves visible through cracks in the rocky ground.  Clusters of driftwood and seashells are strewn about the area, some artfully placed as decoration.  Further downhill and leaning against the cliff face, a portion of a tall driftwood obelisk looms, weathered but standing firm against the coastal winds.</description>
     <position x="-95" y="-460" z="0" />
     <arc exit="southwest" move="southwest" destination="322" />
@@ -2283,21 +2283,21 @@
     <arc exit="down" move="down" destination="323" />
     <arc exit="go" move="go stone steps" destination="315" />
   </node>
-  <node id="321" name="Pivilho Volcano, Ember Aerie Cliffs" color="White">
+  <node id="321" name="Pivilho Volcano, Ember Aerie Cliffs">
     <description>The path widens into a small gathering space, with smoothed volcanic rock forming a natural floor underfoot.  Scattered around the area, small stone piles suggest past gatherings, their rough edges smoothed by years of wind and weather.  Flecks of dried seaweed cling to the edges, carried there by the gusting coastal breeze.</description>
     <position x="-115" y="-460" z="0" />
     <arc exit="east" move="east" destination="320" />
     <arc exit="southeast" move="southeast" destination="323" />
     <arc exit="down" move="down" destination="322" />
   </node>
-  <node id="322" name="Pivilho Volcano, Ember Aerie Cliffs" color="White">
+  <node id="322" name="Pivilho Volcano, Ember Aerie Cliffs">
     <description>This elevated corner of the ledge overlooks the sea below, unidentifiable specks dotting the distant horizon.  Fine cracks in the stone reveal veins of dark mineral deposits, their glossy surfaces reflecting in the light.  A driftwood obelisk stands to the east, its irregular form tucked against the cliff face.</description>
     <position x="-115" y="-440" z="0" />
     <arc exit="northeast" move="northeast" destination="320" />
     <arc exit="east" move="east" destination="323" />
     <arc exit="up" move="up" destination="321" />
   </node>
-  <node id="323" name="Pivilho Volcano, Ember Aerie Cliffs" color="White">
+  <node id="323" name="Pivilho Volcano, Ember Aerie Cliffs">
     <description>Nestled against a natural rock wall, a wide ledge offers reprieve from the constant wind.  Stacked stones form crude seats, their surfaces worn smooth by the elements.  A large driftwood obelisk is visible to the southwest, its sea-worn branches skillfully arranged to resemble an outstretched wing.</description>
     <position x="-95" y="-440" z="0" />
     <arc exit="west" move="west" destination="322" />

--- a/Map99_Aesry_Surlaenis'a.xml
+++ b/Map99_Aesry_Surlaenis'a.xml
@@ -2907,7 +2907,7 @@
     <position x="242" y="161" z="0" />
     <arc exit="go" move="go shadowed alcove" destination="456" />
   </node>
-  <node id="463" name="Aesry Outfitting Society, Reception" note="Outfitting Society|Outfitting prestige" color="White">
+  <node id="463" name="Aesry Outfitting Society, Reception" note="Outfitting Society|Outfitting prestige">
     <description>Billowy sheer curtains have been tied back from the windows to allow a respectable view of the harbor and ocean beyond.  From time to time, rowboats can be seen traveling between the island and their goods-laden ships.  The society's entrance is a wide open, domed room with a singular counter tucked away to one side and branching hallways leading further within.</description>
     <position x="14" y="680" z="0" />
     <arc exit="south" move="south" destination="476" />
@@ -2917,7 +2917,7 @@
     <arc exit="out" move="out" destination="215" />
     <arc exit="go" move="go white archway" destination="487" />
   </node>
-  <node id="464" name="Aesry Outfitting Society, Northern Corridor" color="White">
+  <node id="464" name="Aesry Outfitting Society, Northern Corridor">
     <description>Crushed shells are set into colorful mosaics that form the floor.  Swatches of colorful fabrics are framed along the walls with cards describing their creation process, common uses, and other trivia.  Overhead, gaethzen orbs light the windowless hallway as it branches into working rooms.</description>
     <position x="-6" y="660" z="0" />
     <arc exit="north" move="north" destination="465" />
@@ -2925,22 +2925,22 @@
     <arc exit="southeast" move="southeast" destination="463" />
     <arc exit="northwest" move="northwest" destination="466" />
   </node>
-  <node id="465" name="Aesry Outfitting Society, Lime Spinner's Parlor" note="Spinning2|Lime Spinner" color="White">
+  <node id="465" name="Aesry Outfitting Society, Lime Spinner's Parlor" note="Spinning2|Lime Spinner">
     <description>Plush lime-green carpet covers the floor and serves to soften the creaks and groans made by the nearby spinning wheels.  Gowns and accessories of all types in varying shades of green hang from the ceiling.  While some are basic and may serve as inspiration for beginners, others are quite gaudy and would challenge even the most skilled seamstresses.</description>
     <position x="-6" y="647" z="0" />
     <arc exit="south" move="south" destination="464" />
   </node>
-  <node id="466" name="Aesry Outfitting Society, Apple Spinner's Parlor" note="Spinning1|Apple Spinner" color="White">
+  <node id="466" name="Aesry Outfitting Society, Apple Spinner's Parlor" note="Spinning1|Apple Spinner">
     <description>A large spinning wheel sits atop a nearly room-sized painted bamboo mat.  The mat depicts the island with notable landmarks exaggerated in a stylized manner.  Deep red tapestries with golden embroidery hang from the walls to soften the sounds of the work taking place in other parts of the building.</description>
     <position x="-19" y="647" z="0" />
     <arc exit="southeast" move="southeast" destination="464" />
   </node>
-  <node id="467" name="Aesry Outfitting Society, Plum Spinner's Parlor" note="Spinning3|Plum Spinner" color="White">
+  <node id="467" name="Aesry Outfitting Society, Plum Spinner's Parlor" note="Spinning3|Plum Spinner">
     <description>Paneled walls of dark purple wood enclose the space but do little to soften the sounds of passersby on the streets outside.  Shadows flicker at all hours as people, carts and beasts alike move past the windows as they travel about town.  A large spinning wheel dominates the center of the room, and tailors and seamstresses alike take their turns with it.</description>
     <position x="7" y="647" z="0" />
     <arc exit="southwest" move="southwest" destination="464" />
   </node>
-  <node id="468" name="Aesry Outfitting Society, Central Corridor" color="White">
+  <node id="468" name="Aesry Outfitting Society, Central Corridor">
     <description>Smoothed stone forms the floors here, with a red-tinted grout filling in the spaces between each stone.  Lining either side of the hallway are portraits of renowned tailors, seamstresses, and merchants such as Gortik, Phinara, Keishalae, Loriale, Andriane, and others.  Periodically, a member of the staff will take down one portrait and put up another in its place.  Gaethzen lanterns light the hallway as it opens up into material, tool, and book shops.</description>
     <position x="-6" y="680" z="0" />
     <arc exit="east" move="east" destination="463" />
@@ -2963,7 +2963,7 @@
     <position x="-19" y="693" z="0" />
     <arc exit="northeast" move="northeast" destination="468" />
   </node>
-  <node id="472" name="Aesry Outfitting Society, Southern Corridor" color="White">
+  <node id="472" name="Aesry Outfitting Society, Southern Corridor">
     <description>Padded benches and small tables line either side of the hallway.  Visiting craftsmen and guests alike pause to catch up with one another and hear of news -- fashion and otherwise -- in the far reaches of the realms.  Colorful weaving rooms open up off the end of the hall.</description>
     <position x="-6" y="700" z="0" />
     <arc exit="northeast" move="northeast" destination="463" />
@@ -2971,27 +2971,27 @@
     <arc exit="south" move="south" destination="474" />
     <arc exit="southwest" move="southwest" destination="473" />
   </node>
-  <node id="473" name="Aesry Outfitting Society, Orange Weaver's Hall" note="Weaving1|Orange Weaver" color="White">
+  <node id="473" name="Aesry Outfitting Society, Orange Weaver's Hall" note="Weaving1|Orange Weaver">
     <description>Brightly painted orange walls are illuminated by flickering candlelight that casts dancing shadows across the loom and other furniture of the open space.  Columns of hooks hold countless spools of thread in subtly different shades of color.  A pair of chairs, one high-backed and the other not, sit to either side of a metal-topped worktable.</description>
     <position x="-19" y="713" z="0" />
     <arc exit="northeast" move="northeast" destination="472" />
   </node>
-  <node id="474" name="Aesry Outfitting Society, Lemon Weaver's Hall" note="Weaving2|Lemon Weaver" color="White">
+  <node id="474" name="Aesry Outfitting Society, Lemon Weaver's Hall" note="Weaving2|Lemon Weaver">
     <description>Brightly painted yellow walls are illuminated by flickering candlelight that casts dancing shadows across the loom and other furniture of the open space.  Columns of hooks hold countless spools of thread in subtly different shades of color.  A pair of chairs, one high-backed and the other not, sit to either side of a metal-topped worktable.</description>
     <position x="-6" y="713" z="0" />
     <arc exit="north" move="north" destination="472" />
   </node>
-  <node id="475" name="Aesry Outfitting Society, Strawberry Weaver's Hall" note="Weaving3|Strawberry Weaver" color="White">
+  <node id="475" name="Aesry Outfitting Society, Strawberry Weaver's Hall" note="Weaving3|Strawberry Weaver">
     <description>Brightly painted red walls are illuminated by flickering candlelight that casts dancing shadows across the loom and other furniture of the open space.  Columns of hooks hold countless spools of thread in subtly different shades of color.  A pair of chairs, one high-backed and the other not, sit to either side of a metal-topped worktable.</description>
     <position x="7" y="713" z="0" />
     <arc exit="northwest" move="northwest" destination="472" />
   </node>
-  <node id="476" name="Aesry Outfitting Society, Office" note="Outfitting Office" color="White">
+  <node id="476" name="Aesry Outfitting Society, Office" note="Outfitting Office">
     <description>Cupboards and shelves occupy most of the space here and are filled with all manners of tools of the trade -- pieces of mannequins, lengths of fabric, spools of threads and yarns, tins of buttons and needles, and much more.  Even from this distance, the sound of waves crashing on the shore below can be heard.</description>
     <position x="14" y="693" z="0" />
     <arc exit="north" move="north" destination="463" />
   </node>
-  <node id="477" name="Aesry Engineering Society, Main Hall" note="Engineering Society|Engineering Prestige" color="White">
+  <node id="477" name="Aesry Engineering Society, Main Hall" note="Engineering Society|Engineering Prestige">
     <description>Tall latticework screens encircle conversational nooks, allowing the crafters to relax when not working.  The double doors leading outside stand next to the various boards and banners displaying important information for the society members.  An ornate arch leads east to the office of the master, while a hallway leads north towards the workshops.</description>
     <position x="90" y="219" z="0" />
     <arc exit="north" move="north" destination="481" />
@@ -3000,7 +3000,7 @@
     <arc exit="northwest" move="northwest" destination="480" />
     <arc exit="go" move="go double doors" destination="55" />
   </node>
-  <node id="478" name="Aesry Engineering Society, Office" note="Engineering Office" color="White">
+  <node id="478" name="Aesry Engineering Society, Office" note="Engineering Office">
     <description>Tastefully decorated with pale birch panels along the walls, this airy space serves as the working space for the master of the society.  A paper-covered desk stands proudly in the center of the room while one corner has a leather-upholstered couch near a low table.</description>
     <position x="100" y="219" z="0" />
     <arc exit="west" move="west" destination="477" />
@@ -3015,7 +3015,7 @@
     <position x="80" y="209" z="0" />
     <arc exit="southeast" move="southeast" destination="477" />
   </node>
-  <node id="481" name="Aesry Engineering Society, Hallway" color="White">
+  <node id="481" name="Aesry Engineering Society, Hallway">
     <description>Tall and airy, this wide corridor connects the front part of the society to the working spaces deeper within the building.  A low arch to the east opens up to the depot.</description>
     <position x="90" y="199" z="0" />
     <arc exit="north" move="north" destination="483" />
@@ -3025,17 +3025,17 @@
     <arc exit="northwest" move="northwest" destination="482" />
     <arc exit="go" move="go tall door" destination="486" />
   </node>
-  <node id="482" name="Aesry Engineering Society, Blue Workshop" note="Engineering Blue Workshop|Engineering Workshop1" color="White">
+  <node id="482" name="Aesry Engineering Society, Blue Workshop" note="Engineering Blue Workshop|Engineering Workshop1">
     <description>At one end of the room stands a work bench covered with tools.  Deep grooves and scratches cover the bench's oak surface.  Wood shavings and stone bits dot the rough granite floor below.</description>
     <position x="80" y="189" z="0" />
     <arc exit="southeast" move="southeast" destination="481" />
   </node>
-  <node id="483" name="Aesry Engineering Society, Green Workshop" note="Engineering Green Workshop|Engineering Workshop2" color="White">
+  <node id="483" name="Aesry Engineering Society, Green Workshop" note="Engineering Green Workshop|Engineering Workshop2">
     <description>At one end of the room stands a work bench covered with tools.  Deep grooves and scratches cover the bench's oak surface.  Wood shavings and stone bits dot the rough granite floor below.</description>
     <position x="90" y="189" z="0" />
     <arc exit="south" move="south" destination="481" />
   </node>
-  <node id="484" name="Aesry Engineering Society, Yellow Workshop" note="Engineering Yellow Workshop|Engineering Workshop3" color="White">
+  <node id="484" name="Aesry Engineering Society, Yellow Workshop" note="Engineering Yellow Workshop|Engineering Workshop3">
     <description>At one end of the room stands a work bench covered with tools.  Deep grooves and scratches cover the bench's oak surface.  Wood shavings and stone bits dot the rough granite floor below.</description>
     <position x="100" y="189" z="0" />
     <arc exit="southwest" move="southwest" destination="481" />
@@ -3045,23 +3045,23 @@
     <position x="100" y="199" z="0" />
     <arc exit="west" move="west" destination="481" />
   </node>
-  <node id="486" name="Aesry Engineering Society, A Private Engineering Room" note="486|Private Engineering" color="White">
+  <node id="486" name="Aesry Engineering Society, A Private Engineering Room" note="486|Private Engineering">
     <description>A fine layer of wood and stone shavings covers most of the well-worn granite floor.  The white walls have seen better days, and black and grey scuff marks adorn much of the open space.  A large workstation along one wall is unnaturally free of clutter and holds several organized tools and implements.  Grunts, curses, and labored breathing from other patrons echo throughout the large workroom.</description>
     <position x="80" y="199" z="0" />
     <arc exit="go" move="go tall door" destination="481" />
   </node>
-  <node id="487" name="Aesry Outfitting Society, A Private Outfitting Room" note="487|Private Outfitting" color="White">
+  <node id="487" name="Aesry Outfitting Society, A Private Outfitting Room" note="487|Private Outfitting">
     <description>A pure-white wainscoted hall is topped by lilac-hued paisley painted walls.  Occupying the back third of the room is a solid-looking loom, while a large spinning wheel sits near the entrance.  Resting atop a deep purple rug is a sturdy worktable and a comfortable, wicker chair.  Running parallel along opposing walls are several hooks and shelves, holding practically every conceivable tool, spool of thread, bobbin, thimble and scrap.</description>
     <position x="14" y="667" z="0" />
     <arc exit="go" move="go white archway" destination="463" />
   </node>
-  <node id="488" name="Aesry Alchemy Society, Foyer" note="Alchemy Society|Alchemy prestige" color="White">
+  <node id="488" name="Aesry Alchemy Society, Foyer" note="Alchemy Society|Alchemy prestige">
     <description>Pale paneling of polished wood covers the walls of this spacious room.  Comfortable chairs grouped around low tables provide seating for craftspeople taking breaks from their labors.  Centered on the bamboo floor is an ornately figured rug dyed in pastel colors.</description>
     <position x="470" y="199" z="0" />
     <arc exit="south" move="south" destination="489" />
     <arc exit="go" move="go simple door" destination="37" />
   </node>
-  <node id="489" name="Aesry Alchemy Society, Hallway" color="White">
+  <node id="489" name="Aesry Alchemy Society, Hallway">
     <description>Airy and well lit, the spacious hallway is a hub of bustling activity as craftspeople rush to complete orders.  Clerks thread through the confusion carrying bundles and supplies.</description>
     <position x="470" y="219" z="0" />
     <arc exit="north" move="north" destination="488" />
@@ -3081,7 +3081,7 @@
     <position x="480" y="209" z="0" />
     <arc exit="southwest" move="southwest" destination="489" />
   </node>
-  <node id="492" name="Aesry Alchemy Society, Office" note="Alchemy Office" color="White">
+  <node id="492" name="Aesry Alchemy Society, Office" note="Alchemy Office">
     <description>Pale cream wallpaper covers the walls, a design of small pastel flowers scattered across the surface.  A tall desk stands in the center of the room, its surface covered with piles of papers haphazardly arranged.  A leather chair stands behind the desk, awaiting the Society Master's return to work.</description>
     <position x="490" y="219" z="0" />
     <arc exit="west" move="west" destination="489" />
@@ -3091,7 +3091,7 @@
     <position x="450" y="219" z="0" />
     <arc exit="east" move="east" destination="489" />
   </node>
-  <node id="494" name="Aesry Alchemy Society, Hallway" color="White">
+  <node id="494" name="Aesry Alchemy Society, Hallway">
     <description>Lanterns overhead provide lighting for this spacious passageway, allowing access to the Society's workrooms.  A long runner of plush wool runs down the bamboo flooring, adding a splash of color from its multicolored floral design.</description>
     <position x="470" y="229" z="0" />
     <arc exit="north" move="north" destination="489" />
@@ -3100,22 +3100,22 @@
     <arc exit="southwest" move="southwest" destination="497" />
     <arc exit="go" move="go wooden entryway" destination="498" />
   </node>
-  <node id="495" name="Aesry Alchemy Society, Oak Workroom" note="Alchemy Oak Workroom|Alchemy Workroom3" color="White">
+  <node id="495" name="Aesry Alchemy Society, Oak Workroom" note="Alchemy Oak Workroom|Alchemy Workroom3">
     <description>A set of alchemical equipment is centered in this laboratory, which is paneled in oak planks.  The high ceilings are dotted with small holes that allow deadly gases to eventually escape the room.</description>
     <position x="480" y="239" z="0" />
     <arc exit="northwest" move="northwest" destination="494" />
   </node>
-  <node id="496" name="Aesry Alchemy Society, Pine Workroom" note="Alchemy Pine Workroom|Alchemy Workroom2" color="White">
+  <node id="496" name="Aesry Alchemy Society, Pine Workroom" note="Alchemy Pine Workroom|Alchemy Workroom2">
     <description>A set of alchemical equipment is centered in this laboratory, which is paneled in pine planks.  The high ceilings are dotted with small holes that allow deadly gases to eventually escape the room.</description>
     <position x="470" y="249" z="0" />
     <arc exit="north" move="north" destination="494" />
   </node>
-  <node id="497" name="Aesry Alchemy Society, Workroom" note="Alchemy Workroom|Alchemy Workroom1" color="White">
+  <node id="497" name="Aesry Alchemy Society, Workroom" note="Alchemy Workroom|Alchemy Workroom1">
     <description>A set of alchemical equipment is centered in this laboratory, which is paneled in maple planks.  The high ceilings are dotted with small holes that allow deadly gases to eventually escape the room.</description>
     <position x="460" y="239" z="0" />
     <arc exit="northeast" move="northeast" destination="494" />
   </node>
-  <node id="498" name="Aesry Alchemy Society, A Private Alchemy Room" note="498|Private alchemy" color="White">
+  <node id="498" name="Aesry Alchemy Society, A Private Alchemy Room" note="498|Private alchemy">
     <description>A large workbench dominates one side of the room with numerous pieces of alchemical equipment scattered haphazardly upon its surface.  The high, vented windows provide relief from the common, yet unpleasant, smell that permeates the room.</description>
     <position x="483" y="229" z="0" />
     <arc exit="go" move="go wooden entryway" destination="494" />

--- a/MapTF1_The_Arch.xml
+++ b/MapTF1_The_Arch.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <zone name="The Arch" id="TF1">
-  <node id="1" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="1" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="40" y="120" z="0" />
     <arc name="southeast" hidden="False" destination="3" />
     <arc name="northwest" hidden="False" destination="2" />
     <arc name="go doorway" hidden="False" destination="20" />
   </node>
-  <node id="2" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="2" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="20" y="100" z="0" />
     <arc name="southeast" hidden="False" destination="1" />
     <arc name="go doorway" hidden="False" destination="21" />
   </node>
-  <node id="3" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="3" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="60" y="140" z="0" />
     <arc name="east" hidden="False" destination="4" />
     <arc name="northwest" hidden="False" destination="1" />
     <arc name="go doorway" hidden="False" destination="17" />
   </node>
-  <node id="4" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="4" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="80" y="140" z="0" />
     <arc name="east" hidden="False" destination="5" />
     <arc name="west" hidden="False" destination="3" />
     <arc name="go doorway" hidden="False" destination="18" />
   </node>
-  <node id="5" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="5" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="100" y="140" z="0" />
     <arc name="east" hidden="False" destination="6" />
     <arc name="west" hidden="False" destination="4" />
     <arc name="go doorway" hidden="False" destination="19" />
   </node>
-  <node id="6" name="Droughtman's Maze, The Opal Lounge" note="" color="White">
+  <node id="6" name="Droughtman's Maze, The Opal Lounge" note="">
     <description>The lighting here is dim, but not enough to obscure the opalescent wallpaper.  Couches and upholstered chairs in every shade of the rainbow are scattered around the room in groups, surrounding tables set with food.  A bar occupies one wall, which is hung with a mirror that only magnifies the maelstrom of color in the room.  One has to wonder, is the decor an attempt at opulence, or is it intended to induce patrons to drink more, just to blunt their senses?</description>
     <position x="120" y="140" z="0" />
     <arc name="east" hidden="False" destination="7" />
@@ -45,14 +45,14 @@
     <arc name="go d-sha door" hidden="False" destination="25" />
     <arc name="go d-sh door" hidden="False" destination="26" />
   </node>
-  <node id="7" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="7" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="140" y="140" z="0" />
     <arc name="east" hidden="False" destination="8" />
     <arc name="west" hidden="False" destination="6" />
     <arc name="go doorway" hidden="False" destination="16" />
   </node>
-  <node id="8" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="8" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="160" y="140" z="0" />
     <arc name="east" hidden="False" destination="9" />
@@ -66,75 +66,75 @@
     <arc name="west" hidden="False" destination="8" />
     <arc name="go doorway" hidden="False" destination="14" />
   </node>
-  <node id="10" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="10" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="200" y="120" z="0" />
     <arc name="northeast" hidden="False" destination="11" />
     <arc name="southwest" hidden="False" destination="9" />
     <arc name="go doorway" hidden="False" destination="13" />
   </node>
-  <node id="11" name="Droughtman's Maze, Observation Deck" note="" color="White">
+  <node id="11" name="Droughtman's Maze, Observation Deck" note="">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="220" y="100" z="0" />
     <arc name="southwest" hidden="False" destination="10" />
     <arc name="go doorway" hidden="False" destination="12" />
   </node>
-  <node id="12" name="Droughtman's Maze, The Amethyst Room" note="" color="White">
+  <node id="12" name="Droughtman's Maze, The Amethyst Room" note="">
     <description>Regally stiff, this room bears no knick-knacks or superfluous decoration.  Standing on each side of a large observation window are two pedestals on which two plain oil lamps glow brightly.  A large solitary purple couch stands at the center of the room between two pale purple marble tables.</description>
     <position x="220" y="120" z="0" />
     <arc name="out" hidden="False" destination="11" />
   </node>
-  <node id="13" name="Droughtman's Maze, The Sapphire Room" note="" color="White">
+  <node id="13" name="Droughtman's Maze, The Sapphire Room" note="">
     <description>A large replica of Xibar hangs from the ceiling and rotates slowly, refracting and reflecting the light from surrounding oil lamps so that the room is awash in various shades of blue.  Blue velvet chairs are arranged in various locations around the room, next to small ironwood tables set with small blue votive candleholders.</description>
     <position x="200" y="140" z="0" />
     <arc name="out" hidden="False" destination="10" />
   </node>
-  <node id="14" name="Droughtman's Maze, The Emerald Room" note="" color="White">
+  <node id="14" name="Droughtman's Maze, The Emerald Room" note="">
     <description>Twining around the room, iron ivy vines have been arranged with dark green candles resting precariously upon upturned leaves.  Small wooden trunks topped with emerald green cushions offer firm but comfortable seating.  Upon the wall is a wide window bordered with green-tinted stained glass panels and framed with a soft green moss, which fills the room with a pleasant, earthy aroma.</description>
     <position x="180" y="160" z="0" />
     <arc name="out" hidden="False" destination="9" />
   </node>
-  <node id="15" name="Droughtman's Maze, The Ruby Room" note="" color="White">
+  <node id="15" name="Droughtman's Maze, The Ruby Room" note="">
     <description>Stretching the length of one wall, a large heart-shaped window framed by sheer red curtains looks down on the maze.  Tiered redwood tables topped by a multitude of lit red candles are scattered throughout the room.  Large floor cushions lie around the room to give comfort to those spectators who might wish to relax.</description>
     <position x="160" y="160" z="0" />
     <arc name="out" hidden="False" destination="8" />
   </node>
-  <node id="16" name="Droughtman's Maze, The Diamond Room" note="" color="White">
+  <node id="16" name="Droughtman's Maze, The Diamond Room" note="">
     <description>White marble walls speckled with tiny diamonds enclose a formidable sitting room.  Hanging from the ceiling, a large crystal chandelier bears an array of lit candles, giving off a glorious light reflected through the crystals.  Nestled against the far wall is a plump white sofa, offering comfortable seating to view the ongoing show through the large window on the opposite wall.</description>
     <position x="140" y="160" z="0" />
     <arc name="out" hidden="False" destination="7" />
   </node>
-  <node id="17" name="Droughtman's Maze, The Citrine Room" note="" color="White">
+  <node id="17" name="Droughtman's Maze, The Citrine Room" note="">
     <description>Resting in each corner of this vibrant room are wicker tables laden with yellow and orange candles in various sizes.  Painted upon the wall opposite the observation window is a mural of a rising sun.  Scattered throughout the room are large wicker chairs, each topped with a plush orange or yellow cushion, which provide seating for spectators.</description>
     <position x="60" y="160" z="0" />
     <arc name="out" hidden="False" destination="3" />
   </node>
-  <node id="18" name="Droughtman's Maze, The Moonstone Room" note="" color="White">
+  <node id="18" name="Droughtman's Maze, The Moonstone Room" note="">
     <description>Iridescent walls surround a large circular table of milky quartz set in the center of the moonstone-tiled floor.  One entire wall has been replaced with a large window with opaque designs bordering the edges like frost on a winter-chilled pane.  Simple bentwood silver-birch chairs are turned at an angle to the window, to permit both conversation and a clear view.</description>
     <position x="80" y="160" z="0" />
     <arc name="out" hidden="False" destination="4" />
   </node>
-  <node id="19" name="Droughtman's Maze, The Black Pearl Room" note="" color="White">
+  <node id="19" name="Droughtman's Maze, The Black Pearl Room" note="">
     <description>Dangling from the low ceiling, a black crystal chandelier bearing carved candles illuminates the room.  Sheer curtains, tied neatly at each side with satin ribbons, frame a slightly tinted window.  Plush black silk pillows surround a black ebonwood table in the center of the room.</description>
     <position x="100" y="160" z="0" />
     <arc name="out" hidden="False" destination="5" />
   </node>
-  <node id="20" name="Droughtman's Maze, The Aquamarine Room" note="" color="White">
+  <node id="20" name="Droughtman's Maze, The Aquamarine Room" note="">
     <description>Light blue walls, expertly painted with softly blended swirls of white and blue, give the impression of a room immersed in a soft, cool mist.  Aquamarine-tinted cut-crystal lamps hang from the walls.  Plush sky-blue sofas are arranged in staggered rows and elevated on risers to provide each seated spectator with a clear view out of a large oval window.</description>
     <position x="40" y="140" z="0" />
     <arc name="out" hidden="False" destination="1" />
   </node>
-  <node id="21" name="Droughtman's Maze, The Peridot Room" note="" color="White">
+  <node id="21" name="Droughtman's Maze, The Peridot Room" note="">
     <description>Chairs with cushions in lemon- or lime-green are set about the room, each with its own yellow-and-green-striped glass table.  Splotches of brilliant yellow and splatters of light green paint decorate the walls in abstract patterns.  The light aroma of fresh vanilla drifts from incense holders placed evenly below the observation window.</description>
     <position x="20" y="120" z="0" />
     <arc name="out" hidden="False" destination="2" />
   </node>
-  <node id="22" name="Wharf End, Mer'Kresh" note="Map107_MerKresh.xml|mer'kresh|merkresh|kresh" color="White">
+  <node id="22" name="Wharf End, Mer'Kresh" note="Map107_MerKresh.xml|mer'kresh|merkresh|kresh">
     <description>Through the gaps in the heavy wood planks, one can easily see the waters of Torbis Sanhalas lapping noisily at the pilings.  Although most of the surface of the wharf is covered by a wide assortment of boxes, barrels and shipping goods, there is little that would stop a dropped coin or trinket from vanishing through the slats and sinking into a watery grave.</description>
     <position x="120" y="100" z="0" />
     <arc name="northwest" hidden="False" />
   </node>
-  <node id="23" name="The Crossing, Town Green Southwest" note="Map1_Crossing.xml|crossing" color="White">
+  <node id="23" name="The Crossing, Town Green Southwest" note="Map1_Crossing.xml|crossing">
     <description>The hedgerow to the west meets the row of tall lunat trees that separates the Town Green from the commercial traffic on Lunat Shade Road due south.  The growth is especially dense here, with no way to slip past either of the living fences.  The small thorns on the hedges, to keep out stray livestock in search of prime pasture, look daunting in any case.</description>
     <position x="120" y="100" z="0" />
     <arc name="north" hidden="False" />
@@ -142,14 +142,14 @@
     <arc name="east" hidden="False" />
     <arc name="northeast" hidden="False" />
   </node>
-  <node id="24" name="Riverhaven, Town Square" note="Map30_Riverhaven.xml|riverhaven|haven" color="White">
+  <node id="24" name="Riverhaven, Town Square" note="Map30_Riverhaven.xml|riverhaven|haven">
     <description>This square sits in the space between the Town Hall and the municipal pier.  It is a large park with the graceful gardens of the Temple set within well-tended lawns.  Here and there, benches for the public's use are set out under shady trees, and you can often find an old retired merchant or river captain taking his ease and watching the passing tide of people.</description>
     <position x="120" y="100" z="0" />
     <arc name="north" hidden="False" />
     <arc name="east" hidden="False" />
     <arc name="west" hidden="False" />
   </node>
-  <node id="25" name="North Road, Beech Grove" note="Map40_Langenfirth_to_Theren_Gate.xml|langenfirth|theren|el'bains|elbains" color="White">
+  <node id="25" name="North Road, Beech Grove" note="Map40_Langenfirth_to_Theren_Gate.xml|langenfirth|theren|el'bains|elbains">
     <description>The well-traveled road journeys through a grove of tall beech trees.  Their smooth grey boles converge high above creating a tunnel filled with dappled green sunlight.  Off to the north the grove opens up onto bright meadowlands.</description>
     <description>The well-traveled road journeys through a grove of tall beech trees.  Their smooth grey boles converge high above creating a tunnel of dark shadowy branches that seem to reach out to you.  Off to the north the grove opens up onto moonlit meadowlands.</description>
     <position x="120" y="100" z="0" />
@@ -158,7 +158,7 @@
     <arc name="west" hidden="False" />
     <arc name="southeast" hidden="False" />
   </node>
-  <node id="26" name="Belarritaco Bay, The Galley Dock" note="Map108_M'Riss.xml|mriss" color="White">
+  <node id="26" name="Belarritaco Bay, The Galley Dock" note="Map108_M'Riss.xml|mriss">
     <description>The wide, stout, wooden dock, protected on both sides by rope bumpers, is laden with passengers and goods waiting transport to Mer'Kresh.  Stevedores stand by the galley gangplank or move sacks, crates and barrels to and from the shore.</description>
     <position x="120" y="100" z="0" />
     <arc name="north" hidden="False" />


### PR DESCRIPTION
## Summary

Two-commit cleanup of color attribute usage in map XML files, following the
"always use HEX CODES to ensure maximum compatibility" guidance in README.txt.

### Commit 1 — Convert named room colors to hex codes (8 files, 41 nodes)

Mechanical conversion of the four named colors found in the repo to their
documented hex equivalents:

| Was      | Now       | Meaning              |
|----------|-----------|----------------------|
| `Aqua`   | `#00FFFF` | PC housing           |
| `Red`    | `#FF0000` | purchase room        |
| `Blue`   | `#0000FF` | water room           |
| `Lime`   | `#00FF00` | economic interest    |

### Commit 2 — Remove non-standard `White` color attribute (11 files, 150 nodes)

`White` is not in README.txt's documented color list and has no defined
meaning in the room-color convention. The `color="White"` attribute is
stripped entirely from 150 nodes so those rooms render with the default
color, matching how unclassified rooms are handled elsewhere.

Affected: Map30, Map40a, Map58, Map62, Map69, Map92, Map99, Map108, Map116,
Map150, MapTF1.

## Verification

- Zero named colors remain in any of the 132 XML files in the repo
- All UTF-8 BOMs preserved where they originally existed
- Diff is perfectly balanced (191 insertions, 191 deletions) — no whitespace
  or encoding noise

## Test plan

- [ ] Spot-check a few converted nodes in Genie's automapper to confirm they
      render with the expected color
- [ ] Spot-check a former-`White` node to confirm it renders with the default
      room color