### PR TITLE
Standardize remaining hex colors: convert near-misses to legend, strip undocumented codes

### DIFF
--- a/Map106_Hara'jaal.xml
+++ b/Map106_Hara'jaal.xml
@@ -170,7 +170,7 @@
     <arc exit="north" move="rt north" destination="20" />
     <arc exit="south" move="rt south" destination="29" />
   </node>
-  <node id="28" name="A Hidden Grotto" note="Shrine|Trothfang" color="#4080FF">
+  <node id="28" name="A Hidden Grotto" note="Shrine|Trothfang" color="#A6A3D9">
     <description>Thick brush surrounds this bowl-shaped depression, hiding the outside world from view.  Tall stones, pockmarked with age, encircle an obsidian altar.  The air seems eerily still and empty of noise from the surrounding forest.</description>
     <position x="-60" y="80" z="0" />
     <arc exit="climb" move="climb overgrown slope" destination="20" />

--- a/Map107_Mer'Kresh.xml
+++ b/Map107_Mer'Kresh.xml
@@ -204,135 +204,135 @@
     <arc exit="west" move="west" destination="16" />
     <arc exit="go" move="go library steps" destination="244" />
   </node>
-  <node id="31" name="Mer'Kresh, Gull Circle" note="South Barricade" color="#C0C0C0">
+  <node id="31" name="Mer'Kresh, Gull Circle" note="South Barricade">
     <description>Except for a handful of simple tools such as shovels and hammers, there are few signs of a construction in progress.  The cobblestones are in place, and the edges of the street are lined with stone guardrails.  Only the lack of buildings betrays what work is needed, but meanwhile the empty spaces reveal an unobstructed view of the ocean.</description>
     <position x="220" y="460" z="0" />
     <arc exit="southwest" move="southwest" destination="32" />
     <arc exit="climb" move="climb construction barricade" destination="25" />
   </node>
-  <node id="32" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="32" name="Mer'Kresh, Gull Circle">
     <description>Soldiers of the construction world, wheelbarrows line the edge of the road in tight rows.  Most of them wear the grey and white scars that a load full of stones would leave behind, while others are marked by reddish flakes of rust from exposure to the salty sea air.  For now, the burden they've carried is gone, and rest they will until they are called upon again.</description>
     <position x="200" y="480" z="0" />
     <arc exit="northeast" move="northeast" destination="31" />
     <arc exit="southwest" move="southwest" destination="33" />
   </node>
-  <node id="33" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="33" name="Mer'Kresh, Gull Circle">
     <description>A covering of dirt and pebbles partly masks the cobblestones.  Aside from a good sweeping, this section of the construction area looks in complete readiness to be opened.  Westwards, the gaping maws of open pits and unfinished street surfaces tells a different story, while southwards only the eternal rising and falling of the ocean's waves awaits.</description>
     <position x="180" y="500" z="0" />
     <arc exit="northeast" move="northeast" destination="32" />
     <arc exit="southwest" move="southwest" destination="34" />
   </node>
-  <node id="34" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="34" name="Mer'Kresh, Gull Circle">
     <description>Planks and temporary fences become border guards as Gull Circle curves along its path.  Each of the guardians vigilantly watch over one of several open gaps in the street, protecting both the workers from a fall and the pits from unwelcome additions to their contents.  A clearly defined line cuts across the road where the cobblestones stop and the underlying ridge stones are revealed.</description>
     <position x="160" y="520" z="0" />
     <arc exit="northeast" move="northeast" destination="33" />
     <arc exit="west" move="west" destination="35" />
   </node>
-  <node id="35" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="35" name="Mer'Kresh, Gull Circle">
     <description>The sounds of waves crashing down upon the stones on either side of the road is as regular as a heartbeat, pounding out a steady and noisy rhythm that drowns even the sounds of the ever present sea winds.  Though they can not be heard clearly, the winds make their presence known by whipping at whatever loose objects they find.  Far to the south of this nearby combination of sky and surf, the hazy line of the horizon lay.</description>
     <position x="80" y="520" z="0" />
     <arc exit="east" move="east" destination="34" />
     <arc exit="west" move="west" destination="36" />
   </node>
-  <node id="36" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="36" name="Mer'Kresh, Gull Circle">
     <description>The backs of the buildings and homes of Pearl Circle look across the canal at the construction in progress along Gull Circle.  Many of the structures are reinforced with stone and wood, and few have low windows despite the fact that a thief would have to risk drowning to manage a break-in.  Odd marks along the walls appear to be some form of damage, but a closer examination -- difficult to do from here -- would be necessary to be sure.</description>
     <position x="20" y="520" z="0" />
     <arc exit="east" move="east" destination="35" />
     <arc exit="west" move="west" destination="37" />
   </node>
-  <node id="37" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="37" name="Mer'Kresh, Gull Circle">
     <description>A fair distance to the northwest, the arching form of Zirelga Bridge rises easily from behind the nearby stacks of brick and stone that litter the unfinished street.  One end of the bridge disappears behind the buildings across the canal while the other abruptly stops as it juts out over Gull Circle.  Duplicating the function of the bridge in a small scale, a thick wooden board stretches across one of the pits that are so common along this section of the road.</description>
     <position x="-40" y="520" z="0" />
     <arc exit="east" move="east" destination="36" />
     <arc exit="go" move="go wooden board" destination="38" />
   </node>
-  <node id="38" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="38" name="Mer'Kresh, Gull Circle">
     <description>Looking more like a letter in Gamgweth than a street, the road splits into two halves that straddle a rubble- and water-filled pit.  The walls of the pit reveal the layered construction of Mer'Kresh: the cobblestones rest on a bed of crushed stone that in turn overlays a mass of rubble and broken rock.</description>
     <position x="-220" y="520" z="0" />
     <arc exit="northwest" move="northwest" destination="39" />
     <arc exit="go" move="go wooden board" destination="37" />
   </node>
-  <node id="39" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="39" name="Mer'Kresh, Gull Circle">
     <description>The remains of a seagull lie dead-center in the road, torn to shreds by some predator.  Around the kill, the stones are jagged and cracked, as through something massive collided into them from above.  Wide and open, the sky is unobstructed by buildings or other structures, lending no credence to the concept that the murderer of the gull came from on high.</description>
     <position x="-240" y="500" z="0" />
     <arc exit="southeast" move="southeast" destination="38" />
     <arc exit="northwest" move="northwest" destination="153" />
   </node>
-  <node id="40" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="40" name="Mer'Kresh, Gull Circle">
     <description>The foul stench of uncovered garbage rises from a wide hole in the surface of the road, overwhelming the salty sea breeze.  A circle of gull feathers surrounds the refuse-filled pit, left behind when their previous owners swooped in for a quick meal.  Along one side, a wooden plank has been fastened down to keep the hole from swallowing runaway wheelbarrows.</description>
     <position x="-281" y="460" z="0" />
     <arc exit="southeast" move="southeast" destination="153" />
     <arc exit="northwest" move="northwest" destination="41" />
     <arc exit="climb" move="climb bridge support" />
   </node>
-  <node id="41" name="Mer'Kresh, Zirelga Bridge" color="#C0C0C0">
+  <node id="41" name="Mer'Kresh, Zirelga Bridge">
     <description>A dented wheelbarrow lies beneath the unfinished lip of Zirelga Bridge, its handles cracked and its contents long gone.  At this stage of construction, the bridge is little more than a glorified dumping ramp, used by workers to unload their hauls of garbage.  A stone block, halfway up the support of the bridge, channels the dumped rubbish to one side.  From there, the debris is carried off to fill in holes along the road.</description>
     <position x="-300" y="440" z="0" />
     <arc exit="southeast" move="southeast" destination="40" />
     <arc exit="northwest" move="northwest" destination="42" />
     <arc exit="climb" move="climb stone block" destination="184" />
   </node>
-  <node id="42" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="42" name="Mer'Kresh, Gull Circle">
     <description>The swirling and foaming waters of the ocean churn against the black basalt exposed from beneath the road as a sudden transition takes place.  The rock and wooden framework of a construction in progress yields to the intermittent placement of dark stones rising from the sea.  The rectangular walls are representatives of the first stages of ring-building, and are designed to be platforms to support both workers and the later layers of stones.</description>
     <position x="-320" y="420" z="0" />
     <arc exit="southeast" move="southeast" destination="41" />
     <arc exit="northwest" move="northwest" destination="43" />
   </node>
-  <node id="43" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="43" name="Mer'Kresh, Gull Circle">
     <description>Here, the road is nothing more than the top of several closely packed stone walls.  Shiny from the sea waters washing over them, the largest of the walls flank either side of where the finished road will be, and the spaces between will eventually be filled with rubble, rock and garbage.  The western most wall is severed from this section of the road by a water-filled channel, so any travel to the north must take place across the surface of the eastern one.</description>
     <position x="-340" y="400" z="0" />
     <arc exit="southeast" move="southeast" destination="42" />
     <arc exit="northwest" move="northwest" destination="44" />
   </node>
-  <node id="44" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="44" name="Mer'Kresh, Gull Circle">
     <description>A huge bulge curves out of the wall, filled with gently rocking sea water.  The dark pool of water gurgles with every thrust of the waves, but the walls of its confinement keep it mainly separate from the freedom of the wide ocean.  One large stone, reinforced with wooden supports, sits directly across from the bulge on the other side of the channel that guts the middle of the road.</description>
     <position x="-360" y="380" z="0" />
     <arc exit="southeast" move="southeast" destination="43" />
     <arc exit="northwest" move="northwest" destination="45" />
   </node>
-  <node id="45" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="45" name="Mer'Kresh, Gull Circle">
     <description>Beyond the mirrored twin of this road atop the walls, the ocean heaves, white-caps dancing atop its shifting surface.  Swept away by the tides, bits of driftwood bob in the currents, occasionally rapping against the sides of the stones in the walls before being pulled away and back into Eluned's caress.</description>
     <position x="-380" y="360" z="0" />
     <arc exit="north" move="north" destination="46" />
     <arc exit="southeast" move="southeast" destination="44" />
   </node>
-  <node id="46" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="46" name="Mer'Kresh, Gull Circle">
     <description>Jagged basalt clamors in the surf around the bases of the stone walls, wet and sharp.  Northwards, room to walk is virtually non-existent, replaced by the chaotic piles of the black stones.  Above the rocky clutter, a wooden walkway allows workers to continue with their tasks in relative safety.  Here and south, only the flat tops of the water barrier is available to stand upon.</description>
     <position x="-380" y="276" z="0" />
     <arc exit="south" move="south" destination="45" />
     <arc exit="climb" move="climb wooden steps" destination="47" />
   </node>
-  <node id="47" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="47" name="Mer'Kresh, Gull Circle">
     <description>A temporary pier of scaffolding mounts the walls and tapering dikes to provide workers with sure footing.  Hanging from one of the support beams, a bucket sways in the wind, its contents clattering as it moves.  Just beneath the planking of the makeshift walkway, the explosive sound of the ocean washing over the jumbled stones shakes the wood, and sends the bucket into yet another shifting motion.</description>
     <position x="-380" y="212" z="0" />
     <arc exit="north" move="north" destination="48" />
     <arc exit="climb" move="climb wooden steps" destination="46" />
   </node>
-  <node id="48" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="48" name="Mer'Kresh, Gull Circle">
     <description>Most of the pilings and posts that support the wooden walkway lean askew, pushed off kilter by the movement of the heavy and keen-edged boulders underneath.  The boards, glossy and green from the constant dampness, shudder under the slightest weight or the most gentle push of the wind.  Whenever a particularly potent wave slams into the barrier, some unseen part of the walkway growls angrily as it shakes and repositions itself.</description>
     <position x="-380" y="148" z="0" />
     <arc exit="north" move="north" destination="49" />
     <arc exit="south" move="south" destination="47" />
   </node>
-  <node id="49" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="49" name="Mer'Kresh, Gull Circle">
     <description>Abruptly stopping over a mound of pointed basalt, the walkway lacks any safety features such as guardrails or warning signs.  One heavy black stone in particular is a favorite spot for the waves to dash, if only because its great size presents such a good target.  Just poking from the surface of the waves, another series of black basalt curves in mimicry, shielding this one from the worst of the ocean's assault.</description>
     <position x="-380" y="104" z="0" />
     <arc exit="south" move="south" destination="48" />
     <arc exit="go" move="go black stone" destination="50" />
   </node>
-  <node id="50" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="50" name="Mer'Kresh, Gull Circle">
     <description>Only slightly more stable than its twin to the west, this heap of rock and rubble is at least saved from the most dramatic of swells flooding over both.  All manner of rough stonework is half-buried in the mounds, from cracked sculptures and friezes to the remnants of support columns and paving stones.  Some are glaringly apparent, the white of pitted marble contrasting sharply with the dark basalt.  Others are more subtle, like the mostly-covered face of the statue gazing from the shattered rocks.</description>
     <position x="-380" y="40" z="0" />
     <arc exit="northeast" move="northeast" destination="51" />
     <arc exit="go" move="go wooden walkway" destination="49" />
   </node>
-  <node id="51" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="51" name="Mer'Kresh, Gull Circle">
     <description>The wet, black stones underfoot shift menacingly in the tide, every so often uttering a muffled plop as one of their number slides into the sea.  Thick pilings struggle to keep the pile of stones from vanishing completely under the onslaught of the ocean's power, but their barnacle-encrusted forms betray the weakened state that their time in the water has brought.</description>
     <position x="-340" y="0" z="0" />
     <arc exit="northeast" move="northeast" destination="52" />
     <arc exit="southwest" move="southwest" destination="50" />
   </node>
-  <node id="52" name="Mer'Kresh, Southern Canal Gate" color="#C0C0C0">
+  <node id="52" name="Mer'Kresh, Southern Canal Gate">
     <description>Solidly mortared and built from heavy blocks of basalt, the base for the planned canal gate is closer to completion than the surrounding ring, and stands out from the surrounding pile of rough and loose rock.  Ebbing waves slicken the stones on top of the base with spray and foam.  Caught only by the most violent splashes, a brilliant red banner flutters from atop a wooden pole.</description>
     <position x="-300" y="-40" z="0" />
     <arc exit="southwest" move="southwest" destination="51" />
@@ -699,33 +699,33 @@
     <arc exit="northeast" move="northeast" destination="121" />
     <arc exit="west" move="west" destination="101" />
   </node>
-  <node id="103" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="103" name="Mer'Kresh, Gull Circle">
     <description>Flat and black, the basalt foundations for future shops and homes fill either side of the road, their edges lined with wood guiderails.  The dark grey streaks of ash and lime mortar between the stones creates the illusion that the surfaces are cracked deeply, when in fact the specially made mortar keeps a tight grip on the individual stones.</description>
     <position x="-40" y="-180" z="0" />
     <arc exit="west" move="west" destination="104" />
     <arc exit="climb" move="climb construction barricade" destination="92" />
   </node>
-  <node id="104" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="104" name="Mer'Kresh, Gull Circle">
     <description>Though the road is completed, no structures stand but for one run-down shack huddled quietly off to the side.  A constant sloshing from the canal behind the shack replaces the sounds of workers and townsfolk, and only the occasional cry of a hungry seagull breaks through the noisy water's gurgle.</description>
     <position x="-220" y="-180" z="0" />
     <arc exit="east" move="east" destination="103" />
     <arc exit="southwest" move="southwest" destination="105" />
     <arc exit="southeast" destination="307" />
   </node>
-  <node id="105" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="105" name="Mer'Kresh, Gull Circle">
     <description>Unobstructed by buildings or people, the coast of M'Riss lies serenely across the bay, Torbis Sanhalas.  Beyond the ash-colored sands of the beaches, Undogoz Mountain towers over the woodlands of the main island, a perpetual haze clouding details due to the distance.  Much closer, a series of broken and shattered fences run a circle around one of the finished basalt foundations along the street.</description>
     <position x="-240" y="-160" z="0" />
     <arc exit="northeast" move="northeast" destination="104" />
     <arc exit="southwest" move="southwest" destination="106" />
   </node>
-  <node id="106" name="Mer'Kresh, Gull Circle" note="Super Celpeze" color="#C0C0C0">
+  <node id="106" name="Mer'Kresh, Gull Circle" note="Super Celpeze">
     <description>Thin patches of ashen dirt cover some sections of the road's flagstones, lending the area an unkempt appearance.  The assortment of tools and construction supplies remaining after the workers were done doesn't add to the concept of tidiness.  A stack of leftover bricks sits to one side of the main causeway, no longer needed now that this section of Gull Circle is nearing completion.</description>
     <position x="-260" y="-140" z="0" />
     <arc exit="northeast" move="northeast" destination="105" />
     <arc exit="southwest" move="southwest" destination="107" />
     <arc exit="southeast" move="southeast" destination="311" />
   </node>
-  <node id="107" name="Mer'Kresh, Northern Canal Gate" color="#C0C0C0">
+  <node id="107" name="Mer'Kresh, Northern Canal Gate">
     <description>The most prominent feature of the end of the road is the massive bronze-wrapped tower that will, once finished, hold the northern half of the canal gate in place.  Practically a work of art, the tower stretches high overhead, holding several colorful banners aloft.  Taut ropes run from the midsection, the top, and a point inbetween, down to several metal loops along the ground.  A pile of jagged rocks, discarded from the construction of the road, lean against the ring from inside the canal.</description>
     <position x="-280" y="-120" z="0" />
     <arc exit="northeast" move="northeast" destination="106" />
@@ -1052,7 +1052,7 @@
     <arc exit="southeast" move="swim southeast" destination="133" />
     <arc exit="northwest" move="swim northwest" destination="151" />
   </node>
-  <node id="153" name="Mer'Kresh, Gull Circle" color="#C0C0C0">
+  <node id="153" name="Mer'Kresh, Gull Circle">
     <description>Unless hidden behind the miscellaneous construction tools or stacks of cobblestones, there are no laborers working on the ring.  The deep gouges scarring the edge of the road may have something to do with this, as they are obviously not the result of any shovel or hammer.</description>
     <position x="-260" y="480" z="0" />
     <arc exit="southeast" move="southeast" destination="39" />

--- a/Map108_M'Riss.xml
+++ b/Map108_M'Riss.xml
@@ -1432,28 +1432,28 @@
     <arc exit="southwest" move="southwest" destination="208" />
     <arc exit="northwest" move="northwest" destination="206" />
   </node>
-  <node id="208" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="208" name="Fala Inisharon, The Bog Wallows">
     <description>A gnarled cypress, bent into a wooden parody of a giant bowed under a heavy burden, stands in the muddy soil.  The tree even bears something that resembles a wound: a gash has been ripped into the bark along one side.  Beyond it to the west is a large pool of dirty brown water, home to who knows what kind of creatures.</description>
     <position x="-20" y="300" z="0" />
     <arc exit="northeast" move="northeast" destination="207" />
     <arc exit="west" move="west" destination="209" />
     <arc exit="climb" move="climb cypress" destination="217" />
   </node>
-  <node id="209" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="209" name="Fala Inisharon, The Bog Wallows">
     <description>Scum-covered waters swirl around a moss-shrouded cypress standing in a murky brown pool.  Unknown and unseen inhabitants lurking below the surface stir the water, from which an everpresent fog slowly twists and dances despite the deathly still air.  Rumors say the fog holds the spirits of the fallen, forever trapped in the mist.</description>
     <position x="-60" y="300" z="0" />
     <arc exit="east" move="east" destination="208" />
     <arc exit="northwest" move="northwest" destination="210" />
     <arc exit="climb" move="climb cypress" destination="219" />
   </node>
-  <node id="210" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="210" name="Fala Inisharon, The Bog Wallows">
     <description>The water deepens, making the footing even more uncertain in front of a large cypress tree slowly being strangled by greyish-green vines with big, plate-sized leaves.  The vines drape the tree like a shroud and will eventually pull it down, but for the creature that climbs the tree, they offer a secure handhold, almost as good as a ladder.</description>
     <position x="-80" y="280" z="0" />
     <arc exit="southeast" move="southeast" destination="209" />
     <arc exit="southwest" move="southwest" destination="211" />
     <arc exit="climb" move="climb vine" destination="223" />
   </node>
-  <node id="211" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="211" name="Fala Inisharon, The Bog Wallows">
     <description>From the west comes the noise of rushing water -- no small stream, by the sound of it.  Here, in the midst of a thicket of alder and willow trees, the water is still and knee-deep in some places, but a path can be traced by stepping carefully across the roots of the trees.</description>
     <description>From the west comes the noise of rushing water -- no small stream, by the sound of it.  Here, in the midst of a thicket of alder and willow trees, the water is still and knee-deep in some places, but a path can be traced by stepping carefully across the roots of the trees.  A shaft of sunlight flashes a reflection from something at the base of a willow.</description>
     <position x="-100" y="300" z="0" />
@@ -1469,27 +1469,27 @@
     <arc exit="go" move="go log" destination="230" />
     <arc exit="go" move="go path" destination="265" />
   </node>
-  <node id="213" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="213" name="Fala Inisharon, The Bog Wallows">
     <description>A rocky outcropping like a tilted tabletop stretches far to the north to a jagged peak jutting into the sky.  Through the ravelthorn bushes to the south and west comes the continuous roaring of the Altanen River.</description>
     <description>A rocky outcropping like a tilted tabletop stretches far to the north to a jagged peak jutting into the sky.  Through the ravelthorn bushes to the south and west comes the flash of sunbeams on the Altanen River.</description>
     <position x="-120" y="280" z="0" />
     <arc exit="northeast" move="northeast" destination="214" />
     <arc exit="southwest" move="southwest" destination="212" />
   </node>
-  <node id="214" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="214" name="Fala Inisharon, The Bog Wallows">
     <description>On the crest of a slight rise a massive white oak towers into the sky, a stalwart sentinel.  The ground around the base of the tree is littered with empty acorn caps.  A few slender oak saplings find purchase here and stretch to the sky but are hard pressed to find sunlight in the shade of the behemoth above them.</description>
     <position x="-100" y="260" z="0" />
     <arc exit="east" move="east" destination="215" />
     <arc exit="southwest" move="southwest" destination="213" />
     <arc exit="climb" move="climb oak" destination="303" />
   </node>
-  <node id="215" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="215" name="Fala Inisharon, The Bog Wallows">
     <description>The trail winds between the marsh and the rocky slopes of the Forlorn Hope -- the fabled mountain, Galduta Isharon, visible to the northwest through breaks in the tress.  The stench of decay hangs over the murky brown water lapping along the edge of the path.</description>
     <position x="-80" y="260" z="0" />
     <arc exit="northeast" move="northeast" destination="216" />
     <arc exit="west" move="west" destination="214" />
   </node>
-  <node id="216" name="Fala Inisharon, The Bog Wallows" color="#808080">
+  <node id="216" name="Fala Inisharon, The Bog Wallows">
     <description>The ground is soft underfoot, making a liquid sucking sound with every step.  A discarded boot, now a permanent resident, is lodged nearby, half submerged in the mire.  The surrounding woods are full of the buzz and chitter of insects, and every so often comes a rustling in the brush or something like a muffled footfall.</description>
     <description>The ground is soft underfoot, making a liquid sucking sound with every step.  A discarded boot, now a permanent resident, is lodged nearby, half submerged in the mire.  The surrounding woods are full of birdsong, and every so often comes a rustling in the brush or something like a muffled footfall.</description>
     <position x="-60" y="240" z="0" />

--- a/Map108_M'Riss.xml
+++ b/Map108_M'Riss.xml
@@ -2411,25 +2411,25 @@
     <arc exit="go" move="go fracture" destination="275" />
     <arc exit="go" move="go cave" destination="353" />
   </node>
-  <node id="353" name="Forlorn Hope, Cavern" color="#000000">
+  <node id="353" name="Forlorn Hope, Cavern">
     <description>The brook running from the slopes outside finds an entrance into the cliff face here.  Eons of trickling water have worn a fair-sized chamber into the porous limestone.  Near the back of the room, the stream disappears into a mossy crevice, dropping to who-knows-what depths below.  To either side of the crevice, watercourses long since diverted have washed out even larger openings in the rock.</description>
     <position x="-160" y="180" z="1" />
     <arc exit="northeast" move="northeast" destination="354" />
     <arc exit="northwest" move="northwest" destination="356" />
     <arc exit="out" move="out" destination="352" />
   </node>
-  <node id="354" name="Forlorn Hope, Cavern" color="#000000">
+  <node id="354" name="Forlorn Hope, Cavern">
     <description>This room, the largest by far, has the feeling of a long-abandoned campsite about it, one left in a hurry.  On the upward sloping floor lie rusted buckles, cooking pots, a lantern -- even a good-luck charm perhaps cast off in disgust.  Time and sediment have frozen them all where they fell.  Some effort was made to pile the gear near the walls, leaving the center clear of the worst of the clutter.</description>
     <position x="-140" y="160" z="1" />
     <arc exit="southwest" move="southwest" destination="353" />
     <arc exit="go" move="search climb footholds" destination="355" />
   </node>
-  <node id="355" name="Forlorn Hope, Alcove" color="#000000">
+  <node id="355" name="Forlorn Hope, Alcove">
     <description>A niche, a little above the level of the main chamber, is the driest spot in the cave, and from its vantage the whole room below is visible.  It sits empty, silent, almost waiting.  Some nameless bygone visitor left only one trace: from one of the walls, a bundle of papers juts out, wedged tightly into a crack.</description>
     <position x="-120" y="140" z="1" />
     <arc exit="climb" move="climb footholds" destination="354" />
   </node>
-  <node id="356" name="Forlorn Hope, Cavern" color="#000000">
+  <node id="356" name="Forlorn Hope, Cavern">
     <description>An arm of the stream trickles into a pool the size of a public bath.  The glassy surface of the water reflects the dim light from the entrance, casting cold shadows on walls and ceiling.</description>
     <position x="-180" y="160" z="1" />
     <arc exit="southeast" move="southeast" destination="353" />
@@ -2544,7 +2544,7 @@
     <position x="-80" y="280" z="1" />
     <arc exit="down" move="swim down" destination="373" />
   </node>
-  <node id="375" name="Forlorn Hope, Ledge" color="#000000">
+  <node id="375" name="Forlorn Hope, Ledge">
     <description>The ledge juts from the wall at an upward angle, making for a difficult climb and hiding anyone who might be crouched beyond its rough lip.  Surprisingly broad, the ledge runs almost the length of this broad chamber.  Several scorched spots and a pile of refuse, including fish bones, hint at past use.</description>
     <position x="-100" y="140" z="1" />
     <arc exit="go" move="go stream" destination="364" />

--- a/Map108_M'Riss.xml
+++ b/Map108_M'Riss.xml
@@ -1873,7 +1873,7 @@
     <arc exit="south" move="south" destination="261" />
     <arc exit="go" move="go river" destination="247" />
   </node>
-  <node id="264" name="The Island, A Hunter's Shelter" note="Shelter" color="#C0C0C0">
+  <node id="264" name="The Island, A Hunter's Shelter" note="Shelter">
     <description>Some thoughtful soul has dragged driftwood into a crude shelter and stuffed the larger holes with weeds.  How well it keeps out the rain is anyone's guess, but it offers more protection than anywhere else on the island.</description>
     <position x="-340" y="440" z="0" />
     <arc exit="out" move="out" destination="258" />
@@ -1942,7 +1942,7 @@
     <arc exit="east" move="east" destination="273" />
     <arc exit="up" move="up" destination="277" />
   </node>
-  <node id="275" name="Galduta Isharon, The Outcropping" note="Boulder" color="#C0C0C0">
+  <node id="275" name="Galduta Isharon, The Outcropping" note="Boulder">
     <description>Over the millennia, the outcropping has bowed to its only master, nature: the wind has filled cracks in the rock with bits of silt and mulch from the bogs.  The result is a mottled harmony of bare granite and scrub brush determined to seize life on the barren rocks.  The only flaw in this example of nature's irrestible will is a patch of rusty soil at the base of one boulder, as if over the ages the elements, angry at the affront, had ground something metal under vengeful feet.</description>
     <position x="-180" y="140" z="0" />
     <arc exit="northeast" move="northeast" destination="276" />

--- a/Map108_M'Riss.xml
+++ b/Map108_M'Riss.xml
@@ -2658,7 +2658,7 @@
     <arc exit="southwest" move="southwest" destination="386" />
     <arc exit="go" move="go trail" destination="1" />
   </node>
-  <node id="391" name="Dunes of Despair, High Dunes" note="Elder Armadillos" color="#A020F0">
+  <node id="391" name="Dunes of Despair, High Dunes" note="Elder Armadillos">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="180" y="-130" z="0" />
@@ -2668,7 +2668,7 @@
     <arc exit="southwest" move="southwest" destination="392" />
     <arc exit="go" move="go path" destination="5" />
   </node>
-  <node id="392" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="392" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="160" y="-110" z="0" />
@@ -2677,7 +2677,7 @@
     <arc exit="south" move="south" destination="393" />
     <arc exit="southwest" move="southwest" hidden="True" destination="391" />
   </node>
-  <node id="393" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="393" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="160" y="-90" z="0" />
@@ -2686,7 +2686,7 @@
     <arc exit="south" move="south" hidden="True" destination="391" />
     <arc exit="southwest" move="southwest" destination="393" />
   </node>
-  <node id="394" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="394" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="130" y="-60" z="0" />
@@ -2695,7 +2695,7 @@
     <arc exit="south" move="south" destination="395" />
     <arc exit="southwest" move="southwest" hidden="True" destination="392" />
   </node>
-  <node id="395" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="395" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="130" y="-40" z="0" />
@@ -2704,7 +2704,7 @@
     <arc exit="south" move="south" hidden="True" destination="393" />
     <arc exit="southwest" move="southwest" hidden="True" destination="396" />
   </node>
-  <node id="396" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="396" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="240" y="-140" z="0" />
@@ -2713,7 +2713,7 @@
     <arc exit="south" move="south" hidden="True" destination="397" />
     <arc exit="southwest" move="southwest" hidden="True" destination="401" />
   </node>
-  <node id="397" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="397" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="240" y="-120" z="0" />
@@ -2722,7 +2722,7 @@
     <arc exit="south" move="south" hidden="True" destination="399" />
     <arc exit="southwest" move="southwest" destination="402" />
   </node>
-  <node id="398" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="398" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="160" y="-10" z="0" />
@@ -2731,7 +2731,7 @@
     <arc exit="southwest" move="southwest" destination="397" />
     <arc exit="northwest" move="northwest" hidden="True" destination="401" />
   </node>
-  <node id="399" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="399" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="160" y="-40" z="0" />
@@ -2740,7 +2740,7 @@
     <arc exit="southeast" move="southeast" destination="400" />
     <arc exit="north" move="north" hidden="True" destination="397" />
   </node>
-  <node id="400" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="400" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="180" y="-60" z="0" />
@@ -2749,7 +2749,7 @@
     <arc exit="southwest" move="southwest" destination="399" />
     <arc exit="northwest" move="northwest" hidden="True" destination="398" />
   </node>
-  <node id="401" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="401" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="200" y="-80" z="0" />
@@ -2758,7 +2758,7 @@
     <arc exit="southeast" move="southwest" hidden="True" destination="400" />
     <arc exit="southwest" move="southwest" destination="400" />
   </node>
-  <node id="402" name="Dunes of Despair, High Dunes" color="#A020F0">
+  <node id="402" name="Dunes of Despair, High Dunes">
     <description>An endless expanse of featureless waste stretches in all directions.  In the distance, the desert floor merges with the sky in a hazy, shimmering blur.  The steady breeze whips a spray of fine sand into the air, stinging open eyes.</description>
     <description>The dim illumination of the night reveals a sea of gentle dunes rippling into the distance.  Shadowed troughs and highlighted dune crests mingle teasingly across the desert bed, relieving its otherwise stark emptiness.</description>
     <position x="220" y="-100" z="0" />
@@ -2820,7 +2820,7 @@
     <arc exit="southwest" move="southwest" destination="405" />
     <arc exit="northwest" move="northwest" destination="403" />
   </node>
-  <node id="410" name="Tavayon, Water's Edge" note="Premium Elders" color="#A020F0">
+  <node id="410" name="Tavayon, Water's Edge" note="Premium Elders">
     <description>Numerous spires of obsidian jut around the rim of the crater and smaller fragments speckle the terrain, ranging from mere pebbles to colossal boulders taller than a Gor'Tog.  Meager plant life struggles to eke out an existence in this bleak landscape, growing marginally more abundant as it approaches a brackish oasis to the south.</description>
     <position x="160" y="-220" z="0" />
     <arc exit="southeast" move="southeast" destination="411" />
@@ -2828,14 +2828,14 @@
     <arc exit="southwest" move="southwest" destination="413" />
     <arc exit="go" move="go pass" destination="408" />
   </node>
-  <node id="411" name="Tavayon, Water's Edge" color="#A020F0">
+  <node id="411" name="Tavayon, Water's Edge">
     <description>Numerous spires of obsidian jut around the rim of the crater and smaller fragments speckle the terrain, ranging from mere pebbles to colossal boulders taller than a Gor'Tog.  Meager plant life struggles to eke out an existence in this bleak landscape, growing marginally more abundant as it approaches a brackish oasis to the west.</description>
     <position x="180" y="-200" z="0" />
     <arc exit="southwest" move="southwest" destination="414" />
     <arc exit="west" move="west" destination="412" />
     <arc exit="northwest" move="northwest" destination="410" />
   </node>
-  <node id="412" name="Tavayon, Oasis" color="#A020F0">
+  <node id="412" name="Tavayon, Oasis">
     <description>Shallow, brackish water offers life to the wretched plants that sprout around the shore.  Several salt-encrusted chunks of obsidian spike up through the surface of the water.</description>
     <position x="160" y="-200" z="0" />
     <arc exit="north" move="north" destination="410" />
@@ -2843,14 +2843,14 @@
     <arc exit="south" move="south" destination="414" />
     <arc exit="west" move="west" destination="413" />
   </node>
-  <node id="413" name="Tavayon, Tumulus" color="#A020F0">
+  <node id="413" name="Tavayon, Tumulus">
     <description>Numerous spires of obsidian jut around the rim of the crater and smaller fragments speckle the terrain, ranging from mere pebbles to colossal boulders taller than a Gor'Tog.  Meager plant life struggles to eke out an existence in this bleak landscape, growing marginally more abundant as it approaches a brackish oasis to the east.</description>
     <position x="140" y="-200" z="0" />
     <arc exit="northeast" move="northeast" destination="410" />
     <arc exit="east" move="east" destination="412" />
     <arc exit="southeast" move="southeast" destination="414" />
   </node>
-  <node id="414" name="Tavayon, Water's Edge" color="#A020F0">
+  <node id="414" name="Tavayon, Water's Edge">
     <description>Numerous spires of obsidian jut around the rim of the crater and smaller fragments speckle the terrain, ranging from mere pebbles to colossal boulders taller than a Gor'Tog.  Meager plant life struggles to eke out an existence in this bleak landscape, growing marginally more abundant as it approaches a brackish oasis to the north.</description>
     <position x="160" y="-180" z="0" />
     <arc exit="north" move="north" destination="412" />

--- a/Map116_Hibarnhvidar.xml
+++ b/Map116_Hibarnhvidar.xml
@@ -523,7 +523,7 @@
     <arc exit="north" move="north" destination="69" />
     <arc exit="go" move="go stone building" destination="256" />
   </node>
-  <node id="75" name="Inner Hibarnhvidar, Entry" note="Entry|Kraelyst start point|travel start point" color="#808000">
+  <node id="75" name="Inner Hibarnhvidar, Entry" note="Entry|Kraelyst start point|travel start point">
     <description>Framed at each end by a massive five-sided arch, this long passage is brightly lit by flaming torches in paired iron cressets.  At one end are the stone gates to Outer Hibarnhvidar, lying flat against the smooth walls, ready to be closed should danger threaten.  At the other end, iron gates stand open allowing entrance to the Inner city.  A warm breeze from within the mountain sighs past, carrying the sounds of bustling commerce, and a faint odor of hammered metal.</description>
     <position x="-60" y="90" z="0" />
     <arc exit="go" move="go iron gate" destination="76" />

--- a/Map123_Himineldar_Shel.xml
+++ b/Map123_Himineldar_Shel.xml
@@ -873,7 +873,7 @@
     <arc exit="southwest" move="southwest" destination="126" />
     <arc exit="northwest" move="northwest" destination="89" />
   </node>
-  <node id="126" name="Seord Kerwaith, North Gate" note="Kraelyst start point|travel start point" color="#808000">
+  <node id="126" name="Seord Kerwaith, North Gate" note="Kraelyst start point|travel start point">
     <description>Set within the impressive facade of sharpened logs that enclose the inhabitants of the outpost, the massive iron gate stands as the first defense against those who would wish to claim this land at their own.  High overhead, several guards clad in thick furs keep a careful eye on the landscape, searching for threats that dare challenge the battle savvy Dwarves of Hibarnhvidar.</description>
     <position x="320" y="680" z="0" />
     <arc exit="north" move="north" destination="128" />

--- a/Map127_Boar_Clan.xml
+++ b/Map127_Boar_Clan.xml
@@ -106,7 +106,7 @@
     <arc exit="southwest" move="southwest" destination="16" />
     <arc exit="west" move="west" destination="18" />
   </node>
-  <node id="18" name="Boar Clan, Before the Gate" note="Boar Clan|Gate|Kraelyst start point|travel start point" color="#808000">
+  <node id="18" name="Boar Clan, Before the Gate" note="Boar Clan|Gate|Kraelyst start point|travel start point">
     <description>A massive palisade gate guards the entry to a small village nestled within the forest glade.  Though sharpened points top the upright logs of the palisade, they appear to be the trees of the glade itself embracing the clusters of longhouses within.  Gor'Tog rangers flanking the gate open and close it as needed with a chorus of grunting and the scraping sounds of the wooden gate dragging on the ground as it moves.</description>
     <description>Torches flicker beside a massive palisade gate guarding a small village nestled within the forest glade.  Though sharpened points top the upright logs of the palisade, they appear to be the trees of the glade itself embracing the clusters of longhouses within.  Gor'Tog rangers flanking the gate open and close it as needed with a chorus of grunting and the scraping sounds of the wooden gate dragging on the ground as it moves.</description>
     <position x="180" y="500" z="0" />

--- a/Map14d_Moonmage_Guild.xml
+++ b/Map14d_Moonmage_Guild.xml
@@ -266,7 +266,7 @@
     <arc exit="east" move="east" destination="43" />
     <arc exit="west" move="west" destination="45" />
   </node>
-  <node id="45" name="Platform's Edge, Seat of the Guildmaster" note="Moon Mage Guildleader Tiv" color="#80FF00">
+  <node id="45" name="Platform's Edge, Seat of the Guildmaster" note="Moon Mage Guildleader Tiv" color="#FF8000">
     <description>A large circular stone platform rests suspended in mid-air over the center of the volcano.  The precarious catwalk extends to its edge.</description>
     <position x="-500" y="-400" z="0" />
     <arc exit="east" move="east" destination="44" />

--- a/Map1_Crossing.xml
+++ b/Map1_Crossing.xml
@@ -4354,7 +4354,7 @@
     <position x="130" y="130" z="0" />
     <arc exit="out" move="out" destination="647" />
   </node>
-  <node id="650" name="Riverbank Mudflats, Rough Stairway" note="Map1a_Crossing_Thief.xml|5th Passage" color="#808080">
+  <node id="650" name="Riverbank Mudflats, Rough Stairway" note="Map1a_Crossing_Thief.xml|5th Passage">
     <description>Barely visible in the murky air of the room, broken boards have been set into the earth to form a crude set of steps that tilt precariously away from the base of the panel to drop into the darkness beyond.  Shredded oilcloth has been jammed into the cracks around the panel as if an attempt has been made to prevent light or sounds from betraying activity here to the world outside.</description>
     <position x="130" y="160" z="0" />
     <arc exit="out" move="out" destination="647" />

--- a/Map1_Crossing.xml
+++ b/Map1_Crossing.xml
@@ -310,7 +310,7 @@
     <arc exit="west" move="west" destination="40" />
     <arc exit="go" move="go town hall" destination="311" />
   </node>
-  <node id="42" name="The Crossing, Hodierna Way" note="Kraelyst start point|travel start point" color="#808000">
+  <node id="42" name="The Crossing, Hodierna Way" note="Kraelyst start point|travel start point">
     <description>The hustle of crowds making their way between the secular and religious centers of town that converge here carries you along with its momentum.  The granite and marble facade of the First Provincial Bank catches your eye, standing before you as solid as its name.  A Gor'Tog guard armed with pike and crossbow is posted at the door, while a few well-dressed merchants congregate outside.</description>
     <position x="210" y="20" z="0" />
     <arc exit="east" move="east" destination="160" />

--- a/Map1a_Crossing_Thief.xml
+++ b/Map1a_Crossing_Thief.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <zone name="Crossing Thief" id="1a">
-  <node id="1" name="Underground Passageway" color="#808080">
+  <node id="1" name="Underground Passageway">
     <description>This lengthy passageway is clogged with knife-sized bits of sharp debris.  Overhead several massive boulders block out most of the light, and the din of town traffic is reduced to a surflike roar.  No one stops to glance down between the chinks of rubble, leaving your travels unnoticed and undisturbed.</description>
     <position x="20" y="-80" z="0" />
     <arc exit="northeast" move="northeast" destination="2" />
     <arc exit="go" move="go shadowed gap" destination="4" />
   </node>
-  <node id="2" name="Underground Passageway" color="#808080">
+  <node id="2" name="Underground Passageway">
     <description>Massive boulders from above press deeply into this rubble-strewn area.  Jagged corners of granite lurk everywhere, grinding harshly against each other, and against inhabitants' heads when they don't dodge swiftly enough.</description>
     <position x="40" y="-100" z="0" />
     <arc exit="southwest" move="southwest" destination="1" />
     <arc exit="north" move="north" destination="3" />
     <arc exit="east" move="east" destination="41" />
   </node>
-  <node id="3" name="Underground Passageway" color="#808080">
+  <node id="3" name="Underground Passageway">
     <description>Jagged piles of debris line the center of this passageway, chips and shards of large rocks lodged deep in the low ceiling above.  A fine grey dust blankets everything else, sifting into clouds at knee-level from the passage of thieves.</description>
     <position x="40" y="-120" z="0" />
     <arc exit="south" move="south" destination="2" />
@@ -35,14 +35,14 @@
     <arc exit="south" move="south" />
     <arc exit="west" move="west" />
   </node>
-  <node id="6" name="Riverbank Mudflats" note="Map1_Crossing.xml|Crossing" color="#808080">
+  <node id="6" name="Riverbank Mudflats" note="Map1_Crossing.xml|Crossing">
     <description>Against the rotting warehouse pylons, a makeshift dwelling has been built of broken boxes and stray boards.  A roof composed of dried vilt reeds woven tight and sealed with mud is a temporary but effective relief from the sun.  However, the structure's stopgap construction provides little shelter from the other elements.</description>
     <position x="140" y="-60" z="0" />
     <arc exit="south" move="south" />
     <arc exit="west" move="west" />
     <arc exit="go" move="go panel" destination="7" />
   </node>
-  <node id="7" name="Riverbank Mudflats, Rough Stairway" color="#808080">
+  <node id="7" name="Riverbank Mudflats, Rough Stairway">
     <description>Barely visible in the murky air of the room, broken boards have been set into the earth to form a crude set of steps that tilt precariously away from the base of the panel to drop into the darkness beyond.  Shredded oilcloth has been jammed into the cracks around the panel as if an attempt has been made to prevent light or sounds from betraying activity here to the world outside.</description>
     <position x="120" y="-80" z="0" />
     <arc exit="out" move="out" destination="6" />
@@ -146,31 +146,31 @@
     <arc exit="south" move="south" />
     <arc exit="go" move="go bould" destination="22" />
   </node>
-  <node id="24" name="A Dank Dark Passage" color="#808080">
+  <node id="24" name="A Dank Dark Passage">
     <description>An obstacle course formed of pillaged packing crates in all sizes, shapes and states of decomposition hinders your movement through the passage.  Straw filling, moldy and brown, lies scattered about, jagged edges of rusty metal implements occasionally jutting above the mess.  This is a good place to walk softly.</description>
     <position x="40" y="-40" z="0" />
     <arc exit="southwest" move="southwest" destination="25" />
     <arc exit="go" move="go narrow footholds" destination="29" />
   </node>
-  <node id="25" name="Cluttered, Dank Passage" color="#808080">
+  <node id="25" name="Cluttered, Dank Passage">
     <description>Boxes, sacks, baskets and crates lie upended, splintered, ripped apart and smashed into sawdust.  Numerous fat, bright-eyed rodents stare with unblinking eyes, their whiskers churning thoughtfully.</description>
     <position x="20" y="-20" z="0" />
     <arc exit="northeast" move="northeast" destination="24" />
     <arc exit="south" move="south" destination="26" />
   </node>
-  <node id="26" name="Dark Cluttered Passage" color="#808080">
+  <node id="26" name="Dark Cluttered Passage">
     <description>An obstacle course formed of pillaged packing crates in all sizes, shapes and states of decomposition hinders your movement through the passage.  Straw filling, moldy and brown, lies scattered about, jagged edges of rusty metal implements occasionally jutting above the mess.  This is a good place to walk softly.</description>
     <position x="20" y="0" z="0" />
     <arc exit="north" move="north" destination="25" />
     <arc exit="south" move="south" destination="27" />
   </node>
-  <node id="27" name="Cluttered, Dark Passage" color="#808080">
+  <node id="27" name="Cluttered, Dark Passage">
     <description>Discarded weapons and armor lie heaped about, their jagged edges covered with corrosive rust-colored algae.  Maneuvering past the ruined merchandise is made more difficult by endless rats, madly scurrying through this area in blind panic.</description>
     <position x="20" y="20" z="0" />
     <arc exit="north" move="north" destination="26" />
     <arc exit="southwest" move="southwest" destination="28" />
   </node>
-  <node id="28" name="A Dank, Cluttered Passage" color="#808080">
+  <node id="28" name="A Dank, Cluttered Passage">
     <description>An obstacle course formed of pillaged packing crates in all sizes, shapes and states of decomposition hinders your movement through the passage.  Straw filling, moldy and brown, lies scattered about, jagged edges of rusty metal implements occasionally jutting above the mess.  This is a good place to walk softly.</description>
     <position x="0" y="40" z="0" />
     <arc exit="northeast" move="northeast" destination="27" />
@@ -249,13 +249,13 @@
     <position x="140" y="-80" z="0" />
     <arc exit="out" move="out" destination="6" />
   </node>
-  <node id="41" name="Thieves' Highway" color="#808080">
+  <node id="41" name="Thieves' Highway">
     <description>Smooth stone walls wrap around the tunnel, giving it a circular shape that is just large enough for the tallest Gor'Tog to pass.  Cleared from rubble and trash, the walkway here is uninterrupted in either direction and dimly flickering lights within goat's horn sconces light the passage towards the southeast.  A dark, rubble-filled gloom flickers its shadows across the western path.</description>
     <position x="60" y="-100" z="0" />
     <arc exit="southeast" move="southeast" destination="42" />
     <arc exit="west" move="west" destination="2" />
   </node>
-  <node id="42" name="Thieves' Highway" color="#808080">
+  <node id="42" name="Thieves' Highway">
     <description>Flickering lights, cast from goat's horn sconces, reveal a circular tunnel with a cleared walkway.  Winding swiftly underneath the city overhead, the tunnel is punctuated at one end by a single, darkened doorway cast in shifting shadows.</description>
     <position x="80" y="-80" z="0" />
     <arc exit="northwest" move="northwest" destination="41" />

--- a/Map1m_Crossing_Jadewater.xml
+++ b/Map1m_Crossing_Jadewater.xml
@@ -153,20 +153,20 @@
     <position x="240" y="160" z="0" />
     <arc exit="west" move="west" destination="21" />
   </node>
-  <node id="25" name="Jadewater Mansion, Dining Rotunda" note="Dining Rotunda" color="#C0C0C0">
+  <node id="25" name="Jadewater Mansion, Dining Rotunda" note="Dining Rotunda">
     <description>Under a crystal cupola that reflects the brightness of several lit candelabras lies a long, low table awash in white linen.  Atop it are elegant pewter salvers heaped with steaming viands, their perfumes a mingling of rich scents in the air.  Beverages, sweet or bitter, soft or potent, reside within a mirrored glass case.  Desserts for everyone from the binge-heavy to the diet-conscious await perusal on a majestic gold side cart.</description>
     <position x="100" y="60" z="0" />
     <arc exit="go" move="go graceful archway" destination="12" />
     <arc exit="go" move="go service entrance" destination="26" />
   </node>
-  <node id="26" name="Jadewater Mansion, Kitchen" note="Kitchen" color="#C0C0C0">
+  <node id="26" name="Jadewater Mansion, Kitchen" note="Kitchen">
     <description>Bearing more resemblance to a magical workshop than a place to prepare meals, the kitchen has many oddities filling it.  Herbs overflow from oak shelves while a cart and counter have food and drink waiting to be served.  A small bronze dragon with gaping jaws serves as garbage disposal.</description>
     <position x="120" y="60" z="0" />
     <arc exit="go" move="go service entrance" destination="25" />
     <arc exit="go" move="go trapdoor" destination="27" />
     <arc exit="go" move="go heavy door" destination="28" />
   </node>
-  <node id="27" name="Jadewater Mansion, Wine Cellar" note="Wine Cellar" color="#C0C0C0">
+  <node id="27" name="Jadewater Mansion, Wine Cellar" note="Wine Cellar">
     <description>A small window near the ceiling floods the small basement with a thin stream of light.  Three floor-to-ceiling cases hold hundreds of dusty wine bottles.  The floor is littered with shards of glass and a pile of bottles lies in one corner.</description>
     <position x="140" y="60" z="0" />
     <arc exit="go" move="go trapdoor" destination="26" />

--- a/Map40_Langenfirth_to_Therenborough.xml
+++ b/Map40_Langenfirth_to_Therenborough.xml
@@ -1384,7 +1384,7 @@
     <arc exit="north" move="north" destination="209" />
     <arc exit="southeast" move="southeast" destination="207" />
   </node>
-  <node id="209" name="North Road, Barony Pass" note="gate to Therenborough|Kraelyst start point|travel start point" color="#808000">
+  <node id="209" name="North Road, Barony Pass" note="gate to Therenborough|Kraelyst start point|travel start point">
     <description>With one final sweep, the road straightens out from the hilly pastures in the south to stop at a walled village.  Looming above the stone boundary is the majestic Theren Keep, its battered towers still an imposing sight to behold.</description>
     <position x="200" y="-1316" z="0" />
     <arc exit="south" move="south" destination="208" />

--- a/Map40a_Langenfirth_to_Siksraja.xml
+++ b/Map40a_Langenfirth_to_Siksraja.xml
@@ -336,7 +336,7 @@
     <arc exit="northeast" move="northeast" destination="54" />
     <arc exit="west" move="west" destination="56" />
   </node>
-  <node id="56" name="Svesinek Cels, Quiet Forest" color="#C0C0C0">
+  <node id="56" name="Svesinek Cels, Quiet Forest">
     <description>A large boulder rests on the forest side of the path, diagonally across from what could only be described as a hole, dug in the roadway alongside the split-log fence.  Some vine tendrils that have climbed the fence encircle and sprawl along the wood barrier as far as the eye can see.</description>
     <position x="-1000" y="-100" z="0" />
     <arc exit="east" move="east" destination="55" />
@@ -399,7 +399,7 @@
     <arc exit="southeast" move="southeast" destination="64" />
     <arc exit="northwest" move="northwest" destination="66" />
   </node>
-  <node id="66" name="Svesinek Cels, Foothills" color="#C0C0C0">
+  <node id="66" name="Svesinek Cels, Foothills">
     <description>To the side of the path, an eroded basin in a large slab is home to some stringy weeds that have tenaciously rooted in a damp crevice.  The sickly green weeds relieve the dung-colored monotony of the roadway as it crosses the almost barren landscape.</description>
     <position x="-1200" y="-180" z="0" />
     <arc exit="north" move="north" destination="67" />
@@ -554,7 +554,7 @@
     <arc exit="southeast" move="southeast" destination="91" />
     <arc exit="west" move="west" destination="89" />
   </node>
-  <node id="91" name="Siksraja, Clearing" color="#C0C0C0">
+  <node id="91" name="Siksraja, Clearing">
     <description>The forest halts at a grove of neatly spaced and tended mulberry that covers the land up to the lake, eliminating the cleared expanse that has separated the village.  Two pillars mark the entrance to the village.  Affixed to one of the pillars is an L iron from which hangs a bell and rope.</description>
     <position x="-860" y="-20" z="0" />
     <arc exit="northwest" move="northwest" destination="90" />
@@ -610,7 +610,7 @@
     <arc exit="go" move="go grey tent" destination="195" />
     <arc exit="go" move="go shop" destination="212" />
   </node>
-  <node id="98" name="Siksraja, Cawrs Cels" color="#C0C0C0">
+  <node id="98" name="Siksraja, Cawrs Cels">
     <description>A wood bench, its back to the path, looks out across the clearing.  On one side of the steps leading up to the roofed porch over the General Store is a hitching post.  Affixed to the porch beam above the post is a bell.</description>
     <position x="-920" y="0" z="0" />
     <arc exit="east" move="east" destination="97" />
@@ -645,7 +645,7 @@
     <arc exit="north" move="north" destination="100" />
     <arc exit="climb" move="climb dock" destination="134" />
   </node>
-  <node id="103" name="Siksraja, Clearing" color="#C0C0C0">
+  <node id="103" name="Siksraja, Clearing">
     <description>Grasses of various types grow rampant at the bottom of posts supporting sturdy wood rails that encircle three sides of a ramshackle shed.  The hind side of the enclosure runs along the lake's edge where taller posts keep the fence height uniform though the ground dips towards the shore.  A bell and rope hang from an L iron above the doorway.</description>
     <position x="-1100" y="80" z="0" />
     <arc exit="northeast" move="northeast" destination="73" />
@@ -1091,13 +1091,13 @@
     <arc exit="northeast" move="northeast" destination="167" />
     <arc exit="south" move="south" destination="185" />
   </node>
-  <node id="169" name="Duvli Rinu" color="#C0C0C0">
+  <node id="169" name="Duvli Rinu">
     <description>Space is tight here, under the old oak tree.  Tangled roots and moldy leaves mix with the dirt floor of this narrow, sloping pathway that leads deep into the earth.  In one corner is an empty nest, most likely belonging to a mouse.</description>
     <position x="-1060" y="40" z="1" />
     <arc exit="south" move="south" destination="162" />
     <arc exit="climb" move="climb rope ladder" destination="82" />
   </node>
-  <node id="170" name="Duvli Rinu" color="#C0C0C0">
+  <node id="170" name="Duvli Rinu">
     <description>At first this hole appears to simply drop straight down a few feet, enough to allow one to stand.  As one becomes accustomed to the scant light it is obvious that it widens into a cavern that heads southwest.  The rough floor is dry and dusty and covered with dead leaves that will crunch when stepped upon, which would signal anyone in the tunnel of your arrival.</description>
     <position x="-1040" y="40" z="1" />
     <arc exit="southwest" move="southwest" destination="162" />
@@ -1110,7 +1110,7 @@
     <arc exit="northeast" move="northeast" destination="173" />
     <arc exit="west" move="west" destination="162" />
   </node>
-  <node id="172" name="Duvli Rinu" color="#C0C0C0">
+  <node id="172" name="Duvli Rinu">
     <description>This angled hole slopes sharply as it descends beneath the forest floor.  The air smells damp probably from the small puddles remaining from the last rainfall.  What appears to be a grey tail feather lies near some otherwise indistinguishable remains.</description>
     <position x="-1020" y="40" z="1" />
     <arc exit="south" move="south" destination="171" />
@@ -1128,7 +1128,7 @@
     <arc exit="northeast" move="northeast" destination="186" />
     <arc exit="west" move="west" destination="173" />
   </node>
-  <node id="175" name="Duvli Rinu" color="#C0C0C0">
+  <node id="175" name="Duvli Rinu">
     <description>Dank and dusty, this cramped cavity runs the opposite direction from the hole dug in the ground above.  While it may be the lack of sunlight, the walls here look to be a dark brown, seem crumbly in texture and emit the scent of hay and manure.</description>
     <position x="-960" y="-80" z="1" />
     <arc exit="south" move="south" destination="186" />
@@ -1154,7 +1154,7 @@
     <arc exit="southeast" move="southeast" destination="180" />
     <arc exit="northwest" move="northwest" destination="177" />
   </node>
-  <node id="179" name="Duvli Rinu" color="#C0C0C0">
+  <node id="179" name="Duvli Rinu">
     <description>Dark spots in the earthen walls trace the path of a few tree roots that have spread far from their trunks.  Bits of grass mingle with the dirt in the shored up walls and the bottom of one of the posts protrudes far enough from the ceiling that care must be taken to avoid banging into it.</description>
     <position x="-860" y="60" z="1" />
     <arc exit="west" move="west" destination="178" />
@@ -1185,13 +1185,13 @@
     <arc exit="east" move="east" destination="182" />
     <arc exit="southwest" move="southwest" destination="165" />
   </node>
-  <node id="184" name="Duvli Rinu" color="#C0C0C0">
+  <node id="184" name="Duvli Rinu">
     <description>Muffled voices from above serve as a reminder that silence is golden and any noise made here might well carry overhead.  A damp, cool breeze seems to flow from the southwest, just enough to wonder if the tunnel might be flooded considering its proximity to the lake.</description>
     <position x="-880" y="100" z="1" />
     <arc exit="southwest" move="southwest" destination="183" />
     <arc exit="climb" move="climb rope ladder" destination="98" />
   </node>
-  <node id="185" name="Duvli Rinu" color="#C0C0C0">
+  <node id="185" name="Duvli Rinu">
     <description>Overhead, slats form a latticework that supports the earthen ceiling and constrains dust caused by vibrations from the shed's floorboards.  An odor like fermenting fruit tickles the nose and mingles with the damp-dry scent of the dirt.</description>
     <position x="-1060" y="220" z="1" />
     <arc exit="north" move="north" destination="168" />

--- a/Map4_Crossing_West_Gate.xml
+++ b/Map4_Crossing_West_Gate.xml
@@ -2895,7 +2895,7 @@
     <arc exit="north" move="north" destination="449" />
     <arc exit="south" move="south" destination="447" />
   </node>
-  <node id="449" name="Knife Clan, Sentry" note="Knife Clan|Kraelyst start point|travel start point" color="#808000">
+  <node id="449" name="Knife Clan, Sentry" note="Knife Clan|Kraelyst start point|travel start point">
     <description>A lone Gor'Tog stands motionless, his dark leathers rendering him almost indistinguishable from the surrounding underbrush.  The sentry's eyes scan constantly for signs of danger, the slightest movement instantly drawing his attention.  A low wooden building can be glimpsed off to the west, while to the north the thinning forest gives way to hills.  A rope bridge spans a dry gully south of here.</description>
     <position x="-720" y="-560" z="0" />
     <arc exit="north" move="north" destination="452" />

--- a/Map50_Segoltha_River.xml
+++ b/Map50_Segoltha_River.xml
@@ -53,7 +53,7 @@
     <position x="280" y="100" z="0" />
     <arc exit="east" move="east" />
   </node>
-  <node id="9" name="Segoltha River, Midstream" color="#010165">
+  <node id="9" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="140" z="0" />
     <arc exit="north" move="swim north" destination="7" />
@@ -65,7 +65,7 @@
     <arc exit="west" move="swim west" destination="9" />
     <arc exit="northwest" move="swim northwest" destination="7" />
   </node>
-  <node id="10" name="Segoltha River, Midstream" color="#010165">
+  <node id="10" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="160" z="0" />
     <arc exit="south" move="swim south" destination="11" />
@@ -77,7 +77,7 @@
     <arc exit="southeast" move="swim southeast" destination="10" />
     <arc exit="southwest" move="swim southwest" destination="11" />
   </node>
-  <node id="11" name="Segoltha River, Midstream" color="#010165">
+  <node id="11" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="180" z="0" />
     <arc exit="northeast" move="swim northeast" destination="11" />
@@ -135,7 +135,7 @@
     <arc exit="west" move="swim west" destination="15" />
     <arc exit="northwest" move="swim northwest" destination="14" />
   </node>
-  <node id="16" name="Segoltha River, Midstream" color="#010165">
+  <node id="16" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="280" z="0" />
     <arc exit="north" move="swim north" destination="15" />
@@ -147,7 +147,7 @@
     <arc exit="west" move="swim west" destination="16" />
     <arc exit="northwest" move="swim northwest" destination="15" />
   </node>
-  <node id="17" name="Segoltha River, Midstream" color="#010165">
+  <node id="17" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="300" z="0" />
     <arc exit="north" move="swim north" destination="16" />
@@ -159,7 +159,7 @@
     <arc exit="west" move="swim west" destination="17" />
     <arc exit="northwest" move="swim northwest" destination="16" />
   </node>
-  <node id="18" name="Segoltha River, Midstream" color="#010165">
+  <node id="18" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="320" z="0" />
     <arc exit="north" move="swim north" destination="17" />
@@ -171,7 +171,7 @@
     <arc exit="west" move="swim west" destination="18" />
     <arc exit="northwest" move="swim northwest" destination="17" />
   </node>
-  <node id="19" name="Segoltha River, Midstream" color="#010165">
+  <node id="19" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="340" z="0" />
     <arc exit="north" move="swim north" destination="18" />
@@ -183,7 +183,7 @@
     <arc exit="west" move="swim west" destination="19" />
     <arc exit="northwest" move="swim northwest" destination="18" />
   </node>
-  <node id="20" name="Segoltha River, Midstream" color="#010165">
+  <node id="20" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="360" z="0" />
     <arc exit="north" move="swim north" destination="19" />
@@ -195,7 +195,7 @@
     <arc exit="west" move="swim west" destination="20" />
     <arc exit="northwest" move="swim northwest" destination="19" />
   </node>
-  <node id="21" name="Segoltha River, Midstream" color="#010165">
+  <node id="21" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="380" z="0" />
     <arc exit="north" move="swim north" destination="20" />
@@ -282,7 +282,7 @@
     <arc exit="west" move="swim west" destination="23" />
     <arc exit="northwest" move="swim northwest" destination="22" />
   </node>
-  <node id="32" name="Segoltha River, Midstream" color="#010165">
+  <node id="32" name="Segoltha River, Midstream" color="#000080">
     <description>Twisting currents of silt-laden water surge just below the river's surface.  A churning, heaving mass of dirty brown waves, the torrent of water stretches as far as the eye can see.</description>
     <position x="140" y="100" z="0" />
     <arc exit="north" move="swim north" destination="33" />

--- a/Map63_Oshu'ehhrsk_Manor.xml
+++ b/Map63_Oshu'ehhrsk_Manor.xml
@@ -310,7 +310,7 @@
     <arc exit="north" move="north" destination="51" />
     <arc exit="southeast" move="southeast" destination="49" />
   </node>
-  <node id="51" name="Telpengi'hhs Sara'a, Catacombs" color="#804000">
+  <node id="51" name="Telpengi'hhs Sara'a, Catacombs">
     <description>Even as the scattered bones of those interred here testify, the dead may be free of the fear and pain that the living must endure, but their mortal remains are not spared from sacrilege.  Passing the barriers between life and death, as all mortals must, and fleeing this world for the next might only bear the soul higher -- but that which is left behind may yet be victim to an unguarded fate, as the yawning grave in the mud encrusted ceiling proves.</description>
     <position x="380" y="120" z="0" />
     <arc exit="south" move="south" destination="50" />
@@ -345,7 +345,7 @@
     <arc exit="south" move="south" destination="57" />
     <arc exit="northwest" move="northwest" destination="55" />
   </node>
-  <node id="57" name="Telpengi'hhs Sara'a, Catacombs" color="#804000">
+  <node id="57" name="Telpengi'hhs Sara'a, Catacombs">
     <description>A rectangle of empty space stares down from the dirt of the ceiling, the gap a result of a hollowing out of the grave above.  Littered along the ground are the remains of wood flats and moldy velvet, left behind as if that which emptied the grave could not wait to drag the coffin away, and preferred instead to crack into its contents here.  Of what the pinebox may have contained, there is no sign.</description>
     <position x="500" y="240" z="0" />
     <arc exit="north" move="north" destination="56" />
@@ -363,7 +363,7 @@
     <position x="440" y="200" z="0" />
     <arc exit="down" move="down" destination="47" />
   </node>
-  <node id="60" name="Telpengi'hhs Sara'a, Catacombs" color="#804000">
+  <node id="60" name="Telpengi'hhs Sara'a, Catacombs">
     <description>Cream-colored fabric, torn and soiled, lies half buried, the ripples of cloth flattened and pressed into the dirty floor.  Someone has defiled a grave from the bottom up, tearing out the coffin and the body within and subjecting them to some unknown fate.  Also empty, the burial niches along the walls gaze at the bottom of the grave as if filled with slack-jawed horror at such irreverence.</description>
     <position x="560" y="160" z="0" />
     <arc exit="south" move="south" destination="53" />
@@ -504,7 +504,7 @@
     <arc exit="north" move="north" destination="83" />
     <arc exit="south" move="south" destination="81" />
   </node>
-  <node id="83" name="Overgrown Manor Grounds, Side Yard by the Chapel" color="#804000">
+  <node id="83" name="Overgrown Manor Grounds, Side Yard by the Chapel">
     <description>Some distance above, the glassy remains of an artistically rendered window still display themselves jaggedly along the frame.  Nothing else is left of the artist's impassioned creation, his hours of toil and labor vanished in a shattering of colored fragments.  The wind whistles softly through the remnants, perhaps an echo of the glassworker's lingering spirit bemoaning cruel fate and the razor-like shards left, sharp as a heartache.</description>
     <position x="240" y="260" z="0" />
     <arc exit="south" move="south" destination="82" />
@@ -562,7 +562,7 @@
     <arc exit="southeast" move="southeast" destination="89" />
     <arc exit="northwest" move="northwest" destination="94" />
   </node>
-  <node id="91" name="Overgrown Manor Grounds, Front Lawns" color="#804000">
+  <node id="91" name="Overgrown Manor Grounds, Front Lawns">
     <description>Nearly lost within the clumps of overgrowth are several bits of bone, hiding beneath the twisty blades of grass like frightened refugees.  It is not a secret that they stay there in their place of unobtrusiveness, but more likely that they were discarded when the flesh upon them gave out as the toothy gnaws upon their surfaces indicates.  Though clearly disturbed, a sunken grave nearby doesn't appear to be exhumed enough to be the source of the abandoned bone scraps.</description>
     <position x="300" y="340" z="0" />
     <arc exit="north" move="north" destination="92" />
@@ -604,7 +604,7 @@
     <arc exit="northeast" move="northeast" destination="94" />
     <arc exit="go" move="go carriage door" destination="108" />
   </node>
-  <node id="96" name="Overgrown Manor Grounds, Alfar's Rest Gate" color="#804000">
+  <node id="96" name="Overgrown Manor Grounds, Alfar's Rest Gate">
     <description>But for one nearly barren spot where a sunken grave lies, the weeds cluster in such thick clumps underfoot that the ground seems unnaturally lumpy.  The growth offers little free space, and between the clinging plant life and rusted condition, an old metal gate nearby seems to have no real chance of ever opening again.  Beyond the gate, headstones peek up from a sea of yellowing grass and choking vines.</description>
     <position x="340" y="280" z="0" />
     <arc exit="southwest" move="southwest" destination="85" />

--- a/Map66_STR3.xml
+++ b/Map66_STR3.xml
@@ -475,7 +475,7 @@
     <arc exit="north" move="north" destination="68" />
     <arc exit="south" move="south" destination="70" />
   </node>
-  <node id="70" name="Shard, North Bridge" note="North Bridge|N Bridge|Kraelyst start point|travel start point" color="#808000">
+  <node id="70" name="Shard, North Bridge" note="North Bridge|N Bridge|Kraelyst start point|travel start point">
     <description>To the north of this opulent bridge, the Dragon Spine Mountains span the horizon and exhale a dense forest known simply as the Dragon's Breath.  The North city gates stand close by, guarded by sharp-eyed soldiers on the city wall.</description>
     <position x="-660" y="-200" z="0" />
     <arc exit="north" move="north" destination="69" />

--- a/Map68_Shard_South_Gate.xml
+++ b/Map68_Shard_South_Gate.xml
@@ -311,7 +311,7 @@
     <arc exit="south" move="swim south" destination="49" />
     <arc exit="northwest" move="swim northwest" destination="47" />
   </node>
-  <node id="49" name="Derelict Road, Marsh" color="#808000">
+  <node id="49" name="Derelict Road, Marsh">
     <description>The thick morass of the marsh seems to twist and move as small pockets of air slowly work their way to the surface, releasing a foul stench that fills the area.  The stones from the derelict road are completely gone, forcing travellers to wade through the gross slime.</description>
     <description>The thick morass of the marsh seems to twist and move as small pockets of air slowly work their way to the surface, releasing a foul stench that fills the area.  The stones from the derelict road are completely gone, forcing travelers to wade through the gross slime.</description>
     <position x="60" y="360" z="0" />
@@ -406,7 +406,7 @@
     <arc exit="south" move="rt south" destination="64" />
     <arc exit="northwest" move="rt northwest" destination="62" />
   </node>
-  <node id="64" name="Derelict Road, Darkling Wood" color="#808000">
+  <node id="64" name="Derelict Road, Darkling Wood">
     <description>Tall fingers of timeworn stone thrust up among the imprisoning raevelthorn, hovering like phantoms that watch life pass along the roadway with the cold and detached gaze of eternity.</description>
     <position x="0" y="660" z="0" />
     <arc exit="north" move="rt north" destination="63" />
@@ -418,13 +418,13 @@
     <arc exit="north" move="rt north" destination="64" />
     <arc exit="southwest" move="southwest" destination="66" />
   </node>
-  <node id="66" name="Derelict Road, Darkling Wood" color="#808000">
+  <node id="66" name="Derelict Road, Darkling Wood">
     <description>To the east, an overgrown clearing was once a welcome bit of open space in the thick wood.  Barely visible in the dim light, several rusted chains swing from a tree limb over the clearing, rattling quietly in the wind.</description>
     <position x="-20" y="700" z="0" />
     <arc exit="northeast" move="northeast" destination="65" />
     <arc exit="west" move="rt west" destination="67" />
   </node>
-  <node id="67" name="Derelict Road, Darkling Wood" color="#808000">
+  <node id="67" name="Derelict Road, Darkling Wood">
     <description>The land slopes sharply up to the south and down to the north, holding the mountain path on a narrow ledge cut into the stony earth.  Untouched by daylight, a deep gloom whispers seductively from the heart of the wood, calling travelers into its dark embrace.</description>
     <description>The land slopes sharply up to the south and down to the north, holding the mountain path on a narrow ledge cut into the stony earth.  Untouched by starlight, a deep gloom whispers seductively from the heart of the wood, calling travelers into its dark embrace.</description>
     <position x="-40" y="700" z="0" />

--- a/Map69_Shard_West_Gate.xml
+++ b/Map69_Shard_West_Gate.xml
@@ -62,7 +62,7 @@
     <arc exit="east" move="east" destination="10" />
     <arc exit="west" move="west" destination="8" />
   </node>
-  <node id="10" name="Shard, West Bridge" note="West Bridge|W Bridge|Kraelyst start point|travel start point" color="#808000">
+  <node id="10" name="Shard, West Bridge" note="West Bridge|W Bridge|Kraelyst start point|travel start point">
     <description>Eerie chanting echoes over the bridge, filling the air with an ominous reminder that the World Dragon is still an influential power.  Wyvern Mountain rises up blotting out the western sky.</description>
     <description>The walls of Shard gleam with an inner light rivaling the sun for magnificence, the carefully cut crystal reflecting and refracting light in amazing patterns.  Wyvern Mountain rises up in the west, a huge shadow against the daytime sky.</description>
     <position x="680" y="497" z="0" />
@@ -970,7 +970,7 @@
     <position x="-900" y="177" z="0" />
     <arc exit="west" move="west" destination="166" />
   </node>
-  <node id="168" name="Zaldi Taipa, Cedar Path" note="Kraelyst start point|travel start point" color="#808000">
+  <node id="168" name="Zaldi Taipa, Cedar Path" note="Kraelyst start point|travel start point">
     <description>Silhouetted against the moon-silvered sky, tents are arranged in an orderly grouping that takes maximum advantage of trees that will provide shade in the heat of the day and the partial shelter of a few low ridges.  A nearby clump of juniper lists slightly to one side, almost excavated by something that has dug underneath its low branches to create a hollow in the shadows.</description>
     <description>Silhouetted against the wide prairie sky, colorful tents are arranged in an orderly grouping that takes maximum advantage of shade trees and the partial shelter of a few low ridges.  A nearby clump of juniper lists slightly to one side, almost excavated by something that has dug underneath its low branches to create a hollow in the shadows.</description>
     <position x="-740" y="337" z="0" />

--- a/Map8_Crossing_East_Gate.xml
+++ b/Map8_Crossing_East_Gate.xml
@@ -7,7 +7,7 @@
     <arc exit="southeast" move="southeast" destination="39" />
     <arc exit="west" move="west" destination="2" />
   </node>
-  <node id="2" name="Eastern Tier, Outside Gate" color="#808040">
+  <node id="2" name="Eastern Tier, Outside Gate">
     <description>The eastern gate of the Crossing stands before you, an incomplete, but serviceable stone structure.  To the north are grey slate hills rising out of dense clumps of deobar trees and groves of tall almur poplars.  The land to the east is flat, and dips and rises almost imperceptibly into the distance.  A single, wide path winds through it, surrounded by ruins, debris and small huts.</description>
     <position x="140" y="26" z="0" />
     <arc exit="east" move="east" destination="1" />

--- a/Map90_Ratha.xml
+++ b/Map90_Ratha.xml
@@ -1139,28 +1139,28 @@
     <arc exit="south" move="south" destination="168" />
     <arc exit="west" move="west" destination="134" />
   </node>
-  <node id="168" name="Ratha, Upper Cobra Road" color="#80FFFF">
+  <node id="168" name="Ratha, Upper Cobra Road" color="#00FFFF">
     <description>A few houses, set back from the road, seem to brood in silence.  They are shuttered and look unkempt, their gardens gone to seed and their paint is peeling.  The damp night air thickens into fog and swirls about the dim wooden shapes.  There is evidence of a fire not too recently, to judge from the rain-streaked soot around the windows and doors and the smoke-stained walls of one house.</description>
     <description>A few houses, set back from the road, seem to brood in silence.  They are shuttered and look unkempt, their gardens gone to seed and their paint is peeling.  Even the laughter and shouting of children playing nearby seems oddly muted and listless.  There is evidence of a fire not too recently, to judge from the smoke-stained walls of one house.</description>
     <position x="58" y="-179" z="0" />
     <arc exit="north" move="north" destination="167" />
     <arc exit="southwest" move="southwest" destination="169" />
   </node>
-  <node id="169" name="Ratha, Upper Cobra Road" color="#80FFFF">
+  <node id="169" name="Ratha, Upper Cobra Road" color="#00FFFF">
     <description>The road winds a bit between tidy cottages set between neat stone hedges.  One or two appear to be shuttered and empty, but most show signs of being occupied and maintained.  Each has a small brass or bronze night lantern set over the door.</description>
     <description>The road winds a bit between tidy cottages set between neat stone hedges.  One or two appear to be shuttered and empty, but most show signs of being occupied and maintained.  A large group of children of several races are engaged in some game for which the rules are seemingly random, but no doubt they make sense to the players.  Much of it seems to entail raucous shouting and laughter from all involved.</description>
     <position x="38" y="-159" z="0" />
     <arc exit="northeast" move="northeast" destination="168" />
     <arc exit="southwest" move="southwest" destination="170" />
   </node>
-  <node id="170" name="Ratha, Upper Cobra Road" color="#80FFFF">
+  <node id="170" name="Ratha, Upper Cobra Road" color="#00FFFF">
     <description>One and two-story houses press close along the avenue.  Through shuttered windows, one can hear people going about their night-time activities.  A small lantern hangs over each door, as required by local custom.  Somewhere, the heavy tread of a watchman on his rounds echoes in the night air.</description>
     <description>One and two-story houses press close along the busy avenue.  Through open windows, one can see people going about their everyday lives, untroubled by the passing parade of travelers.</description>
     <position x="18" y="-139" z="0" />
     <arc exit="northeast" move="northeast" destination="169" />
     <arc exit="southwest" move="southwest" destination="171" />
   </node>
-  <node id="171" name="Ratha, Upper Cobra Road" color="#80FFFF">
+  <node id="171" name="Ratha, Upper Cobra Road" color="#00FFFF">
     <description>Tall houses crowd together along both sides of the road, their half-timbered second stories leaning towards each other until they almost meet overhead.  The sky is nearly blocked, giving a gloomy feel to the passage between them that is offset by the cheery color schemes and sprays of greenery set in vases along the window ledges.  Somewhere, a sibilant voice is singing, accompanied by a less-than-skilled ocarina player.</description>
     <position x="-2" y="-119" z="0" />
     <arc exit="northeast" move="northeast" destination="170" />
@@ -1174,7 +1174,7 @@
     <arc exit="southeast" move="southeast" destination="223" />
     <arc exit="south" move="south" destination="173" />
   </node>
-  <node id="173" name="Ratha, Upper Cobra Road" color="#80FFFF">
+  <node id="173" name="Ratha, Upper Cobra Road" color="#00FFFF">
     <description>Several small gardens, each with a tidy stone border, line the road along the edge of a genteel residential area.  Several tall stakes control long strands of curling vines, laden with pea-pods.</description>
     <description>Several small gardens, each with a tidy stone border, line the road along the edge of a genteel residential area.  Several tall stakes control long strands of curling vines, laden with pea-pods.  A brace of geese wander about, pecking at half-buried seeds in the dirt.</description>
     <position x="-22" y="-79" z="0" />
@@ -1201,54 +1201,54 @@
     <arc exit="east" move="east" destination="200" />
     <arc exit="west" move="west" destination="177" />
   </node>
-  <node id="177" name="Ratha, Mastik Mews" color="#80FFFF">
+  <node id="177" name="Ratha, Mastik Mews" color="#00FFFF">
     <description>As the throng of citizens heads north from the lifts, this delightful little road heads west over the ridge toward some of the most beautiful scenery Ratha has to offer.  Weeping bloodwood trees form a graceful arch over the roadway, while neat white pickets surround a cluster of tidy homes.</description>
     <position x="-62" y="-19" z="0" />
     <arc exit="east" move="east" destination="176" />
     <arc exit="northwest" move="northwest" destination="178" />
   </node>
-  <node id="178" name="Ratha, Mastik Mews" color="#80FFFF">
+  <node id="178" name="Ratha, Mastik Mews" color="#00FFFF">
     <description>Sweet scents float through the calm night air.  Glowing embers from the cooking fires die slowly, the residents long taken to their beds, and slumbering peacefully.</description>
     <description>All around, the signs of a thriving community abound.  Young children, actively play in the streets and yards of the well kept homes, while women hang laundry out on lines to dry.  Conspicuously missing are the men, likely away at sea, the craft-halls or out hunting to stock the family larder.  On both sides of the lane, bright jadsem blossoms and freesia lend a pleasant sweet scent to the air.</description>
     <position x="-82" y="-39" z="0" />
     <arc exit="southeast" move="southeast" destination="177" />
     <arc exit="west" move="west" destination="179" />
   </node>
-  <node id="179" name="Ratha, Mastik Mews" note="Water Trough" color="#80FFFF">
+  <node id="179" name="Ratha, Mastik Mews" note="Water Trough" color="#00FFFF">
     <description>Spectres of the afternoon hustle and bustle are called forth by the soft whinny of a horse nearby.  The sparkling night view of the city below and the roiling ocean beyond is a joy to behold.</description>
     <description>Horse drawn carts amble past, laden with goods from the marketplace to the north.  A driver stops to water his horse at one of the many troughs along the tree-lined route.  Toward the southwest, a beautiful unobstructed view of the ocean awaits the passerby, eager for a break from their daily chores.</description>
     <position x="-122" y="-39" z="0" />
     <arc exit="east" move="east" destination="178" />
     <arc exit="northwest" move="northwest" destination="180" />
   </node>
-  <node id="180" name="Ratha, Mastik Mews" color="#80FFFF">
+  <node id="180" name="Ratha, Mastik Mews" color="#00FFFF">
     <description>The neighborhood garden is silent, resting after a busy day of cultivation and activity.  A bustling center of activity by day, the garden lends quiet comfort to this quaint community in the long evening hours.</description>
     <description>Bees buzz happily, finding a wealth of pollen in the neat rows of flowers and vegetables of a community garden.  Neighbors chat casually as they share in the toils of tending the plot.  Covered and protected against the elements, the more delicate of the fruits and flowers flourish under the added attention.</description>
     <position x="-142" y="-59" z="0" />
     <arc exit="southeast" move="southeast" destination="179" />
     <arc exit="west" move="west" destination="181" />
   </node>
-  <node id="181" name="Ratha, Mastik Mews" color="#80FFFF">
+  <node id="181" name="Ratha, Mastik Mews" color="#00FFFF">
     <description>Several people gather around a large brick firepit outside a neatly trimmed cottage.  Billowing smoke wraps around the stone chimney as a wild boar turns slowly over the coals, fat dripping into the flames.  On smaller spits, a number of plump birds roast slowly, and large pots of bubbling liquids add their steam and delicious smells to the atmosphere.</description>
     <position x="-162" y="-59" z="0" />
     <arc exit="east" move="east" destination="180" />
     <arc exit="west" move="west" destination="182" />
   </node>
-  <node id="182" name="Ratha, Odalva Reach" color="#80FFFF">
+  <node id="182" name="Ratha, Odalva Reach" color="#00FFFF">
     <description>The well worn stone wall nearly rings with the day's conversations.  Now quiet and peaceful, this delightful lane wends its way through the slumbering community.</description>
     <description>Delicious smells permeate the air, creating an atmosphere of comfort and home.  All who stroll down this delightful lane are pulled aside to visit or partake in a sip of grog or cold spring water.  A trio of old women, leaning across a stone wall, are enrapt in a story telling session, oblivious to the world around them.</description>
     <position x="-182" y="-59" z="0" />
     <arc exit="east" move="east" destination="181" />
     <arc exit="west" move="west" destination="183" />
   </node>
-  <node id="183" name="Ratha, Odalva Reach" color="#80FFFF">
+  <node id="183" name="Ratha, Odalva Reach" color="#00FFFF">
     <description>Fingers of starlight filter through the lush canopy of bloodwood and sana'ati trees as the avenue broadens.  Protected from the frequent wind and rain sweeping off the ocean, the drive takes on an almost dream-like quality.  On the north side of the reach, gentle rolling knolls are host to a variety of well kept homes with dramatic views of the sparkling sea beyond the cliffs.</description>
     <description>Fingers of light filter through the lush canopy of bloodwood and sana'ati trees as the avenue broadens.  Protected from the afternoon sun or the wind and rain sweeping off the ocean, the drive takes on an almost dream-like quality.  On the north side of the reach, gentle rolling knolls are host to a variety of well kept homes with dramatic views of the crystal sea beyond the cliffs.</description>
     <position x="-202" y="-59" z="0" />
     <arc exit="east" move="east" destination="182" />
     <arc exit="southwest" move="southwest" destination="184" />
   </node>
-  <node id="184" name="Ratha, Odalva Reach" color="#80FFFF">
+  <node id="184" name="Ratha, Odalva Reach" color="#00FFFF">
     <description>The denseness of the arboreal adit gives way briefly, allowing an unobstructed view of the shipyards far below, and the jetty beyond.  From this vantage point one can clearly observe the traffic in and out of the harbor.  It is said that the Odalva family purchased property on this bluff to keep track of the vast Redthorne fleet.</description>
     <position x="-222" y="-39" z="0" />
     <arc exit="northeast" move="northeast" destination="183" />
@@ -1277,19 +1277,19 @@
     <arc exit="climb" move="climb driftwood fence" destination="297" />
     <arc exit="go" move="go winding trail" destination="298" />
   </node>
-  <node id="188" name="Ratha, Odalva Reach" note="Garthic NEW" color="#80FFFF">
+  <node id="188" name="Ratha, Odalva Reach" note="Garthic NEW" color="#00FFFF">
     <description>Skirting along the meadow, the road ambles toward the cliff's edge and two large homes, perched precariously close to the precipice.  On the opposite side of the road, stables and gardens make best use of the grassy knoll and ample acreage.</description>
     <position x="-322" y="-39" z="0" />
     <arc exit="northeast" move="northeast" destination="187" />
     <arc exit="northwest" move="northwest" destination="189" />
   </node>
-  <node id="189" name="Ratha, Odalva Reach" note="Ssarkhl NEW" color="#80FFFF">
+  <node id="189" name="Ratha, Odalva Reach" note="Ssarkhl NEW" color="#00FFFF">
     <description>Subtle fragrances waft through the air, hibiscus, cherry blossom, something else not quite identifiable.  Carstens, the florist, has gardens nearby and often roams the neighborhood selling his delicate and fresh-picked wares to the eager locals.</description>
     <position x="-342" y="-59" z="0" />
     <arc exit="southeast" move="southeast" destination="188" />
     <arc exit="west" move="west" destination="190" />
   </node>
-  <node id="190" name="Ratha, Odalva Reach" color="#80FFFF">
+  <node id="190" name="Ratha, Odalva Reach" color="#00FFFF">
     <description>Breezes blow stronger here, as the road approaches the western overlook and the windward side of the bluff.  The thick stand of sana'ati gives way to smaller, sculpted pine trees.  Though still ornamental and pleasant to look upon, the plants and flowers here have adapted to the elements, taking on a distinctly squat and sturdy posture.</description>
     <position x="-362" y="-59" z="0" />
     <arc exit="east" move="east" destination="189" />
@@ -1307,27 +1307,27 @@
     <arc exit="northeast" move="northeast" destination="193" />
     <arc exit="south" move="south" destination="191" />
   </node>
-  <node id="193" name="Ratha, Selridge Road" color="#80FFFF">
+  <node id="193" name="Ratha, Selridge Road" color="#00FFFF">
     <description>Windblown grasses cling to sandy cracks in the walkways that bypass several tidy homes along the road.  Iron gates and covered porticos offer security and protection from the evening elements.  Tall and stately street lamps perform their nightly ritual, offering a ray or two of warm light to the evening stroller.</description>
     <description>Windblown grasses cling to sandy cracks in the walkways that bypass several tidy homes along the road.  Iron gates and shaded porticos offer privacy and shelter from the afternoon sun while tall and stately street lamps await a nightly ritual, offering a ray or two of warm light to the evening stroller.</description>
     <position x="-362" y="-79" z="0" />
     <arc exit="north" move="north" destination="194" />
     <arc exit="southwest" move="southwest" destination="192" />
   </node>
-  <node id="194" name="Ratha, Selridge Road" color="#80FFFF">
+  <node id="194" name="Ratha, Selridge Road" color="#00FFFF">
     <description>Tempests and whorls of salty air whip past, sending sand and dust flying inland.  Gnarled and deformed by the constant wind, a stand of dwarf pine hum as if goading the spirits of the wind into a battle of wits.</description>
     <position x="-362" y="-99" z="0" />
     <arc exit="northeast" move="northeast" destination="195" />
     <arc exit="south" move="south" destination="193" />
   </node>
-  <node id="195" name="Ratha, Selridge Road" color="#80FFFF">
+  <node id="195" name="Ratha, Selridge Road" color="#00FFFF">
     <description>Spicy and aromatic, the scents of a growing herb garden drift past.  Rich and loamy, the soil and climate here are perfect for growing everything from brilliant flowers to flavorful vegetables.  Just ahead the welcoming lights of the Carstens farmhouse can be seen towering over darkened gardens.</description>
     <description>Spicy and aromatic, the scents of a growing herb garden drift past.  Rich and loamy, the soil and climate here are perfect for growing everything from brilliant flowers to flavorful vegetables.  Just ahead the white gables of the Carstens farmhouse can be seen towering over neat rows of blooming finery.</description>
     <position x="-342" y="-119" z="0" />
     <arc exit="north" move="north" destination="196" />
     <arc exit="southwest" move="southwest" destination="194" />
   </node>
-  <node id="196" name="Ratha, Selridge Road" color="#80FFFF">
+  <node id="196" name="Ratha, Selridge Road" color="#00FFFF">
     <description>Wild grapevines along a rickety fence cast strange shadows from the lamplight in the dark.  Sweet smells from the gardens beyond lend to the intoxicating environment along the tree-lined road.</description>
     <description>Vibrant lavender and wild grape vines adorn a rickety fence along the western edge of the Carstens place.  Folks amble past, stopping to smell the sweet flowers and admire the upcoming crop of unusual floral varieties that Carstens is famous for.  Dwarf pine and an occasional silverwood tree line the inlaid walkways along the road, a rich mosaic nearly lost in the sand from the cliff.</description>
     <position x="-342" y="-139" z="0" />
@@ -1340,7 +1340,7 @@
     <arc exit="north" move="north" destination="198" />
     <arc exit="southwest" move="southwest" destination="196" />
   </node>
-  <node id="198" name="Ratha, Selridge Road" color="#80FFFF">
+  <node id="198" name="Ratha, Selridge Road" color="#00FFFF">
     <description>Continuing the inlaid stone motif, a high wall protects the street here from the whipping winds that frequent this side of the bluff.  In the distance, the tinkle of chimes plays an erratic melody in harmony with the constant drone of the city, and the crashing surf beyond the cliffs.</description>
     <position x="-322" y="-179" z="0" />
     <arc exit="south" move="south" destination="197" />
@@ -1372,14 +1372,14 @@
     <arc exit="east" move="east" destination="203" />
     <arc exit="west" move="west" destination="201" />
   </node>
-  <node id="203" name="Ratha, Kor'adu Avenue" color="#80FFFF">
+  <node id="203" name="Ratha, Kor'adu Avenue" color="#00FFFF">
     <description>A few steps off the road, atop a slight rise, a bevy of small cottages beckon the weary home for the evening.  Clean and well cared for, the homes in this area are neither shabby nor elegant.</description>
     <description>A few steps off the road, atop a slight rise, a bevy of small cottages are oriented toward the remarkable view of the ocean beyond.  Clean and well cared for, the homes in this area are neither shabby nor elegant.  Bescarved housewives are often seen traversing the walkways and crossing the street to chat with passing salesman.</description>
     <position x="78" y="-19" z="0" />
     <arc exit="southeast" move="southeast" destination="204" />
     <arc exit="west" move="west" destination="202" />
   </node>
-  <node id="204" name="Ratha, Kor'adu Avenue" color="#80FFFF">
+  <node id="204" name="Ratha, Kor'adu Avenue" color="#00FFFF">
     <description>The avenue sweeps toward the south and east and a lovely view of the city below.  The sparkling ocean, ever present from nearly every spot in Ratha is a constant reminder of the hard working way of life the town has to offer.</description>
     <position x="98" y="1" z="0" />
     <arc exit="east" move="east" destination="205" />
@@ -1409,45 +1409,45 @@
     <arc exit="northeast" move="northeast" destination="209" />
     <arc exit="southwest" move="southwest" destination="207" />
   </node>
-  <node id="209" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="209" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>A cluster of homes is set back away from the traffic of the avenue, taking advantage of the view from atop a slight rise.  A dirt lane serves as a drive connecting the homes to the road, forming what could be construed as a cul-de-sac.</description>
     <position x="198" y="-19" z="0" />
     <arc exit="north" move="north" destination="210" />
     <arc exit="southwest" move="southwest" destination="208" />
   </node>
-  <node id="210" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="210" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>Both spectacular and dangerous, the view at this point is nonetheless exhilarating.  The stone wall protects the average traveler from the perilous cliffs, but too eager a spectator could easily find themselves awash in the churning surf and the rocks below.</description>
     <position x="198" y="-39" z="0" />
     <arc exit="north" move="north" destination="211" />
     <arc exit="south" move="south" destination="209" />
   </node>
-  <node id="211" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="211" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>Fields and walkways are quiet and settled for another night's slumber.  Come morning, the eager voices of children at play will once again carry aloft on the gentle breezes.</description>
     <description>Gentle breezes blow on this side of the island.  Beyond the low fence of a large field children are often seen at play, hiding behind large boulders or stone walls, they frequently imitate hunters who range far beyond the limits of the city.</description>
     <position x="198" y="-59" z="0" />
     <arc exit="south" move="south" destination="210" />
     <arc exit="northwest" move="northwest" destination="212" />
   </node>
-  <node id="212" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="212" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>A wide brick walkway commands the eastern side of the bluff, as the drive takes a turn toward the most beautiful of scenic finery on Ratha.  Stretching as far as the eye can see, a sparkling crystal ocean lays like a blanket surrounding the island.</description>
     <position x="178" y="-79" z="0" />
     <arc exit="north" move="north" destination="213" />
     <arc exit="southeast" move="southeast" destination="211" />
   </node>
-  <node id="213" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="213" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>A quiet, tree-lined lane meanders off toward the west.  Unable to wander past the confines of a locked gate, the passerby is left to wonder what manner of mystery lays beyond the iron scrollwork.  Birdsong and laughter are carried aloft on a soft breeze, reminders of a carefree existence somewhere closeby.</description>
     <position x="178" y="-99" z="0" />
     <arc exit="south" move="south" destination="212" />
     <arc exit="northwest" move="northwest" destination="214" />
   </node>
-  <node id="214" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="214" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>Charming cottages and small homes sit close together, tiled walkways and neat gardens setting one apart from the other.  Residents can often be seen sitting on porches late into the night, puffing on pipes, drinking cider or just watching the stars play upon the ocean.</description>
     <description>Charming cottages and small homes sit close together, tiled walkways and neat gardens setting one apart from the other.  Women gather in the largest of several yards, discussing the events of the day.</description>
     <position x="158" y="-119" z="0" />
     <arc exit="north" move="north" destination="215" />
     <arc exit="southeast" move="southeast" destination="213" />
   </node>
-  <node id="215" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="215" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>The avenue is broad and decidedly residential.  The homes are not overly large or elegant, but well kept and nicely appointed.  The children who often play in the gardens and along the walkways, are tucked into their beds slumbering now as the stars come out to play.</description>
     <description>The avenue is broad and decidedly residential.  The homes are not overly large or elegant, but well kept and nicely appointed.  A group of children can often be seen playing in the gardens and along the walkways, shouting happily to one another.</description>
     <position x="158" y="-139" z="0" />
@@ -1468,20 +1468,20 @@
     <arc exit="southeast" move="southeast" destination="216" />
     <arc exit="northwest" move="northwest" destination="218" />
   </node>
-  <node id="218" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="218" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>A row of neatly trimmed buildings sits back off the road, warm lamplight radiating from the windows.  Most businesses, which are closed for the night, leave a lamp or candle burning to inform townsfolk that the owners are in residence and available for emergencies.</description>
     <description>Neat and well kept buildings are set back from the road here.  Townsfolk scurry by, engaged in animated conversation, on their way to perform one errand or another.</description>
     <position x="118" y="-199" z="0" />
     <arc exit="north" move="north" destination="219" />
     <arc exit="southeast" move="southeast" destination="217" />
   </node>
-  <node id="219" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="219" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>A young family makes their way along the stone walkway toward the south and the beautiful views of the ocean.  A sturdy stone wall abuts the walkway and provides a safe barrier from the treachery of the sheer cliff beyond.</description>
     <position x="118" y="-239" z="0" />
     <arc exit="south" move="south" destination="218" />
     <arc exit="west" move="west" destination="220" />
   </node>
-  <node id="220" name="Ratha, Tierskel Way" color="#80FFFF">
+  <node id="220" name="Ratha, Tierskel Way" color="#00FFFF">
     <description>Carriage traffic is very sporadic during the quiet hours of the evening and early morning.  On occasion a group of drunken sailors ambles through, lost from the main thoroughfare and creating a disturbance in the quiet neighborhood awaking angry residents from their slumber.</description>
     <description>Carriages trundle in both directions, barely enough time is had to avoid the hooves of the great equines as they prance at a feverish pace.</description>
     <position x="98" y="-239" z="0" />
@@ -1495,26 +1495,26 @@
     <arc exit="northwest" move="northwest" destination="222" />
     <arc exit="go" move="go forge" destination="305" />
   </node>
-  <node id="222" name="Ratha, Kor'adu Avenue" color="#80FFFF">
+  <node id="222" name="Ratha, Kor'adu Avenue" color="#00FFFF">
     <description>Several lovely homes find themselves ensconced amid neatly clipped shrubbery and tidy walkways.  Serviceable if not attractive fencing provides a bit of security to the urban neighborhood.</description>
     <position x="18" y="-59" z="0" />
     <arc exit="southeast" move="southeast" destination="221" />
     <arc exit="northwest" move="northwest" destination="223" />
     <arc exit="go" move="go forge" destination="221" />
   </node>
-  <node id="223" name="Ratha, Kor'adu Avenue" color="#80FFFF">
+  <node id="223" name="Ratha, Kor'adu Avenue" color="#00FFFF">
     <description>A tiny shed sits at quite a peculiar angle just off the avenue, adjoined to an equally peculiar little cottage.  Sumptuous smells often linger in the air here, making the cottage the frequent subject of local prattle.</description>
     <position x="-2" y="-79" z="0" />
     <arc exit="southeast" move="southeast" destination="222" />
     <arc exit="northwest" move="northwest" destination="172" />
   </node>
-  <node id="224" name="Ratha, Kor'adu Avenue" color="#80FFFF">
+  <node id="224" name="Ratha, Kor'adu Avenue" color="#00FFFF">
     <description>Bright awnings and colorful pennants adorn the facade of a neat mud and brick building.  A lovely portico dotted with delightful iron chairs and matching tables offer weary shoppers a place to stop and catch their breath.</description>
     <position x="-22" y="-119" z="0" />
     <arc exit="south" move="south" destination="172" />
     <arc exit="northwest" move="northwest" destination="225" />
   </node>
-  <node id="225" name="Ratha, Kor'adu Avenue" color="#80FFFF">
+  <node id="225" name="Ratha, Kor'adu Avenue" color="#00FFFF">
     <description>The darkened facade of a large building casts a shadow on the street below.  A wall of wooden crates blocks passage along the walkway, forcing pedestrians into the street and the path of trotting hoofbeats.</description>
     <position x="-42" y="-139" z="0" />
     <arc exit="southeast" move="southeast" destination="224" />
@@ -3718,34 +3718,34 @@
     <arc exit="northwest" move="northwest" destination="609" />
     <arc exit="go" move="go silver-trimmed lift" destination="633" />
   </node>
-  <node id="583" name="Shh'o'kumu Terrace, Promenade East" color="#80FFFF">
+  <node id="583" name="Shh'o'kumu Terrace, Promenade East" color="#00FFFF">
     <description>Large pots of flowers dot the perfect promenade.  Along the elegant balustrades, passersby stop to enjoy the view of the ocean far beyond and the bustling palace district below.</description>
     <description>Large pots of flowers that are vibrant by day, cast long elegant shadows on the perfect brickwork of the walkway by night.  Beyond the marble balustrades, the lights of the palace and gardens present a luminous spectacle beyond measure.</description>
     <position x="-22" y="-829" z="0" />
     <arc exit="east" move="east" destination="584" />
     <arc exit="west" move="west" destination="582" />
   </node>
-  <node id="584" name="Shh'o'kumu Terrace, Promenade East" color="#80FFFF">
+  <node id="584" name="Shh'o'kumu Terrace, Promenade East" color="#00FFFF">
     <description>Elegant willows drape comforting arms over the pristine walkway.  Lending a hand to stir a cooling breeze or protect from the biting sun, the ancient trees enhance the loveliness of the promenade.</description>
     <description>Elegant willows drape comforting arms over the pristine walkway.  Lending a hand to stir a cooling breeze or filter the sparkling moonlight, the ancient trees enhance the loveliness of the promenade.</description>
     <position x="-2" y="-829" z="0" />
     <arc exit="northeast" move="northeast" destination="585" />
     <arc exit="west" move="west" destination="583" />
   </node>
-  <node id="585" name="Shh'o'kumu Terrace, Promenade East" color="#80FFFF">
+  <node id="585" name="Shh'o'kumu Terrace, Promenade East" color="#00FFFF">
     <description>Beautiful topiaries adorn the expansive walkway, in striking contrast to the simple beauty of the sparkling sea.  Large wagons laden with provisions traverse the cobbled avenue, drivers anxious to make deliveries on time to any one of several large estates in the vicinity.</description>
     <description>Beautiful topiaries by day take on strange, almost monstrous shapes by night.  Far beyond the elaborate balustrades and the sheer cliffs, the velvet sea shimmers with tiny points of reflected light.</description>
     <position x="18" y="-849" z="0" />
     <arc exit="northeast" move="northeast" destination="586" />
     <arc exit="southwest" move="southwest" destination="584" />
   </node>
-  <node id="586" name="Shh'o'kumu Terrace, Promenade East" color="#80FFFF">
+  <node id="586" name="Shh'o'kumu Terrace, Promenade East" color="#00FFFF">
     <description>The rows of windswept willows and stately ironwood shade the walkways along the promenade.  Tantalizing smells wend their way toward appreciative bystanders and fade into the salt-sea air and the city beyond.</description>
     <position x="38" y="-869" z="0" />
     <arc exit="northeast" move="northeast" destination="587" />
     <arc exit="southwest" move="southwest" destination="585" />
   </node>
-  <node id="587" name="Shh'o'kumu Terrace, Promenade East" color="#80FFFF">
+  <node id="587" name="Shh'o'kumu Terrace, Promenade East" color="#00FFFF">
     <description>Several lovely homes are set back from the road, framed in a backdrop of rolling green acres and towering trees.  The views from this vantage point are breathtaking, whether it be the lovely terrace itself or the sparkling ocean beyond.</description>
     <position x="58" y="-889" z="0" />
     <arc exit="north" move="north" destination="588" />
@@ -3765,7 +3765,7 @@
     <arc exit="south" move="south" destination="588" />
     <arc exit="northwest" move="northwest" destination="590" />
   </node>
-  <node id="590" name="Shh'o'kumu Terrace, Por'oson Drive" color="#80FFFF">
+  <node id="590" name="Shh'o'kumu Terrace, Por'oson Drive" color="#00FFFF">
     <description>A low ivy covered wall brings the expansive greenery of the terrace into view as the drive skirts the northeast border of the lovely Deversham park.  Toward the southwest the beauty of the ocean catches the eye of all who traverse this section of town.</description>
     <position x="38" y="-939" z="0" />
     <arc exit="southeast" move="southeast" destination="589" />
@@ -3777,7 +3777,7 @@
     <arc exit="southeast" move="southeast" destination="590" />
     <arc exit="northwest" move="northwest" destination="592" />
   </node>
-  <node id="592" name="Shh'o'kumu Terrace, Por'oson Drive" color="#80FFFF">
+  <node id="592" name="Shh'o'kumu Terrace, Por'oson Drive" color="#00FFFF">
     <description>The pace of traffic is chaotic at times as the drive approaches the Por'oson Gate.  Travelers mill about asking directions to their destinations or seeking transportation to the distant locales beyond the city limits.</description>
     <position x="-2" y="-979" z="0" />
     <arc exit="southeast" move="southeast" destination="591" />
@@ -3823,26 +3823,26 @@
     <arc exit="east" move="east" destination="597" />
     <arc exit="southwest" move="southwest" destination="599" />
   </node>
-  <node id="599" name="Shh'o'kumu Terrace, Sur'oson Drive" color="#80FFFF">
+  <node id="599" name="Shh'o'kumu Terrace, Sur'oson Drive" color="#00FFFF">
     <description>The low half wall is replaced by a high, stone and timber wall which serves as a barrier to the great wilderness beyond the city limits.  To the east, views of regal drives and sumptuous acres greet the visitor or passerby.</description>
     <description>The low half wall is replaced by a high, stone and timber wall which serves as a barrier to the great wilderness beyond the city limits.  To the east, the regal drives are darkened, and soft lights dot the expansive acreage as the community slumbers.</description>
     <position x="-142" y="-959" z="0" />
     <arc exit="northeast" move="northeast" destination="598" />
     <arc exit="southwest" move="southwest" destination="600" />
   </node>
-  <node id="600" name="Shh'o'kumu Terrace, Sur'oson Drive" color="#80FFFF">
+  <node id="600" name="Shh'o'kumu Terrace, Sur'oson Drive" color="#00FFFF">
     <description>Shining tiled roofs, lush topiary gardens and manicured grounds present the onlooker with a beautiful view.  As gorgeous as the surrounding neighborhoods are, they all pale in comparison to the timeless beauty of the ocean to the west.</description>
     <position x="-162" y="-939" z="0" />
     <arc exit="northeast" move="northeast" destination="599" />
     <arc exit="southwest" move="southwest" destination="601" />
   </node>
-  <node id="601" name="Shh'o'kumu Terrace, Sur'oson Drive" color="#80FFFF">
+  <node id="601" name="Shh'o'kumu Terrace, Sur'oson Drive" color="#00FFFF">
     <description>A stiff breeze blows here constantly, on the windward side of the terrace.  A gentle slope rises from the road toward the east covered with softly waving grasses and wild flowers.  An old stone bench allows travelers a chance to sit and enjoy the view.</description>
     <position x="-182" y="-919" z="0" />
     <arc exit="northeast" move="northeast" destination="600" />
     <arc exit="south" move="south" destination="602" />
   </node>
-  <node id="602" name="Shh'o'kumu Terrace, Promenade West" color="#80FFFF">
+  <node id="602" name="Shh'o'kumu Terrace, Promenade West" color="#00FFFF">
     <description>Fine marble arches of the promenade loom to the south, their polished surfaces glinting with reflected light.  Families often stroll here, taking in the crisp air and the remarkable sights.  Several exquisite homes are nestled back from the road amid lush, manicured lawns.</description>
     <position x="-182" y="-904" z="0" />
     <arc exit="north" move="north" destination="601" />
@@ -3856,7 +3856,7 @@
     <arc exit="east" move="east" destination="621" />
     <arc exit="southeast" move="southeast" destination="604" />
   </node>
-  <node id="604" name="Shh'o'kumu Terrace, Promenade West" color="#80FFFF">
+  <node id="604" name="Shh'o'kumu Terrace, Promenade West" color="#00FFFF">
     <description>Swirling winds howl through the marble arches as the walkway turns toward the northeast.  Shielded from much of the wind, families stroll comfortably along the walk enjoying the dramatic views.</description>
     <description>Large marble arches shelter the walkway from the brisk evening breezes.  Crystal highlights glance off the ocean to the west lending an almost dreamlike quality to this section of the promenade.</description>
     <position x="-162" y="-869" z="0" />
@@ -3869,13 +3869,13 @@
     <arc exit="southeast" move="southeast" destination="606" />
     <arc exit="northwest" move="northwest" destination="604" />
   </node>
-  <node id="606" name="Shh'o'kumu Terrace, Promenade West" color="#80FFFF">
+  <node id="606" name="Shh'o'kumu Terrace, Promenade West" color="#00FFFF">
     <description>The marble of the balustrade is used to create a series of arches that offer a bit of protection from the constant breeze.  Elegant rose vines climb their marbled surfaces and paint a pretty picture against the azure of the sea beyond.</description>
     <position x="-122" y="-829" z="0" />
     <arc exit="east" move="east" destination="607" />
     <arc exit="northwest" move="northwest" destination="605" />
   </node>
-  <node id="607" name="Shh'o'kumu Terrace, Promenade West" color="#80FFFF">
+  <node id="607" name="Shh'o'kumu Terrace, Promenade West" color="#00FFFF">
     <description>Perfectly polished walkways and matching marble balustrades reflect just a portion of the incredible finery found on this tier.  Liveried carriages roll past conveying their occupants toward the sumptuous estates on the eastern side of the terrace.</description>
     <position x="-102" y="-829" z="0" />
     <arc exit="east" move="east" destination="608" />
@@ -3956,14 +3956,14 @@
     <arc exit="east" move="east" destination="616" />
     <arc exit="southwest" move="southwest" destination="618" />
   </node>
-  <node id="618" name="Shh'o'kumu Terrace, Zsikiel Lane" color="#80FFFF">
+  <node id="618" name="Shh'o'kumu Terrace, Zsikiel Lane" color="#00FFFF">
     <description>Delicious smells of roasting meats, spices and freshly baked bread waft past on a luscious breeze.  Somewhere closeby, the kitchen staff of a nearby estate prepares a sumptuous meal for the family and their guests.</description>
     <description>Lingering smells of the evenings repast waft through the air, the scent of cinnamon and coffee still strong.  Somewhere closeby, warming fires and relaxed conversation enfold the hard-working staff of any of the nearby estates, as they relax a bit and focus on their own families.</description>
     <position x="-112" y="-909" z="0" />
     <arc exit="northeast" move="northeast" destination="617" />
     <arc exit="southeast" move="southeast" destination="619" />
   </node>
-  <node id="619" name="Shh'o'kumu Terrace, Zsikiel Lane" color="#80FFFF">
+  <node id="619" name="Shh'o'kumu Terrace, Zsikiel Lane" color="#00FFFF">
     <description>The soft tinkle of chimes and the scent of roses mingles on a breeze.  Alongside the lane, a low white fence marks the sumptuous boundary of a formal garden.  A series of elaborate fountains punctuates the sculpted greenery as it spans east toward some incredibly beautiful homes.</description>
     <position x="-102" y="-899" z="0" />
     <arc exit="southwest" move="southwest" destination="620" />

--- a/Map90_Ratha.xml
+++ b/Map90_Ratha.xml
@@ -3545,7 +3545,7 @@
     <arc exit="down" move="down" destination="554" />
     <arc exit="climb" move="climb edge" destination="552" />
   </node>
-  <node id="554" name="Eluned's Temple, Pool" color="#0080FF">
+  <node id="554" name="Eluned's Temple, Pool" color="#0000FF">
     <description>Some light filters down from above, but beneath the water looks dark and deep.  What may lurk there is anyone's guess.</description>
     <position x="-372" y="-609" z="0" />
     <arc exit="up" move="swim up" destination="553" />

--- a/Map90_Ratha.xml
+++ b/Map90_Ratha.xml
@@ -1025,7 +1025,7 @@
     <position x="-302" y="-299" z="0" />
     <arc exit="south" move="south" destination="147" />
   </node>
-  <node id="152" name="Ratha, Zeh'ra Boulevard" color="#FF0080">
+  <node id="152" name="Ratha, Zeh'ra Boulevard">
     <description>A lissome S'kra Mur man stumbles up a short walkway leading to one of the townhouses built here.  Judging from his unsteady walk and the amount of trouble the latch causes, he's returning from more than a hard day's work.  No lights are visible in any of the windows facing the street and a cool wind blows in from the bay bringing with it the quiet susurration of the surf.</description>
     <description>The incessant noise of the Bazaar is somewhat muted next to the sheer cliff face rising up to the most prosperous section of the city.  Tasteful etchings adorn the lintels of cozy townhouses built back from the street.  A steady flow of commercial traffic forces pedestrians to keep to the edges of the thoroughfare in order to keep life and limb intact.</description>
     <position x="-202" y="-259" z="0" />
@@ -2926,7 +2926,7 @@
     <arc exit="west" move="west" destination="458" />
     <arc exit="go" move="go gate" destination="460" />
   </node>
-  <node id="458" name="Ratha, West Regents Circle" color="#FF0080">
+  <node id="458" name="Ratha, West Regents Circle">
     <description>Roaming vendors are often seen along the expansive drive.  Offerings such as rare teas and sugared pastries are among the delicacies enjoyed by all who stroll the luxurious circle.  Birds and other small creatures often dart among the passersby, eager to covet a treasured ort.</description>
     <description>The vendors have gone for the evening, the circle is now quiet.  In the morning, they'll be back offering warm drinks and luscious treats to the privileged citizens who travel this route.</description>
     <position x="-162" y="-339" z="0" />

--- a/Map90_Ratha.xml
+++ b/Map90_Ratha.xml
@@ -2525,7 +2525,7 @@
     <position x="318" y="-469" z="0" />
     <arc exit="south" move="south" destination="391" />
   </node>
-  <node id="395" name="Temple of Hodierna, Holy Sanctuary" note="Shrine4-02|Hodierna" color="#4080FF">
+  <node id="395" name="Temple of Hodierna, Holy Sanctuary" note="Shrine4-02|Hodierna" color="#A6A3D9">
     <description>The main part of the temple is dedicated to the goddess herself.  Entering through the arch, the first thing your eyes rest upon is the wall directly opposite the entrance.  An awe-inspiring mural of Hodierna, made out of thousands of tiny colored tiles, covers the entire length of the sanctuary.  Each tile is carefully placed, detailing the goddess' features, giving her an almost life-like appearance.  The altar is made of a pure white marble and polished to a lustrous shine.</description>
     <position x="318" y="-449" z="0" />
     <arc exit="go" move="go ivory arch" destination="391" />
@@ -2544,7 +2544,7 @@
     <arc exit="climb" move="climb stone steps" destination="396" />
     <arc exit="go" move="go domed building" destination="398" />
   </node>
-  <node id="398" name="Phelim's Temple, Planetarium" note="hrine4-03|Phelim|Planetarium" color="#4080FF">
+  <node id="398" name="Phelim's Temple, Planetarium" note="hrine4-03|Phelim|Planetarium" color="#A6A3D9">
     <description>The domed roof of the temple is closed and the constellations are projected on the ceiling and walls in a splendid display of the heavens.  The floor stones are black marble and glisten softly in the dim light, and the dark walls are cool and smooth to the touch.</description>
     <description>The domed roof of Phelim's temple is open to the night sky with a large telescope pointed towards the heavens.</description>
     <position x="338" y="-519" z="0" />
@@ -2877,7 +2877,7 @@
     <arc exit="northeast" move="northeast" destination="448" />
     <arc exit="south" move="south" destination="456" />
   </node>
-  <node id="450" name="A Pine Thicket" note="Shrine4-01|Dark Aspects|Pine Thicket" color="#4080FF">
+  <node id="450" name="A Pine Thicket" note="Shrine4-01|Dark Aspects|Pine Thicket" color="#A6A3D9">
     <description>The scent of pine resin and decaying wood permeates this dark stand of trees.  The sky is completely blocked from view by the overhanging boughs, and the air is still and suffocating.  There is a sense of being watched, by something.</description>
     <position x="198" y="-499" z="0" />
     <arc exit="northeast" move="northeast" destination="451" />
@@ -2901,7 +2901,7 @@
     <position x="238" y="-459" z="0" />
     <arc exit="northwest" move="northwest" destination="452" />
   </node>
-  <node id="454" name="Chadatru's Temple, Forecourt" note="Shrine4-09|Chadatru" color="#4080FF">
+  <node id="454" name="Chadatru's Temple, Forecourt" note="Shrine4-09|Chadatru" color="#A6A3D9">
     <description>A row of columns frames the tall, broad temple building that rises ahead.  This small courtyard consists of white pebbles, various aloe planted along the low walls, and a small altar placed against the western wall.  A fountain above the altar spills fresh water over its surface, keeping the altar glistening in the bright light.</description>
     <description>A row of columns frames the tall, broad temple building that rises ahead.  Hundreds of burning candles rest on the low courtyard walls, illuminating this small forecourt and brightening the white pebbles underfoot.  A fountain above the altar on the western wall spills fresh water over its surface, keeping the altar glistening softly in the candle light.</description>
     <position x="138" y="-419" z="0" />
@@ -3453,7 +3453,7 @@
     <arc exit="go" move="go round building" destination="539" />
     <arc exit="north" move="north" destination="530" />
   </node>
-  <node id="539" name="Faenella's Temple, Sanctum" note="Shrine4-05|Faenella" color="#4080FF">
+  <node id="539" name="Faenella's Temple, Sanctum" note="Shrine4-05|Faenella" color="#A6A3D9">
     <description>Smooth, dark wooden walls curve around this tall narrow room.  The only window is a skylight above a pale statue of Faenella, sculpted kneeling before a basin of water placed in the center of the space.  One half of the room is strung with golden wires that run from the floor to the ceiling, and sound in the chamber vibrates them to a pleasing tone.</description>
     <description>Smooth, dark wooden walls curve around this tall narrow room.  A skylight from above brightens the pale statue of Faenella kneeling before a basin of water placed in the center of the space.  One half of the room is strung with golden wires that run from the floor to ceiling, and sound in the chamber vibrates them to a pleasing tone.</description>
     <position x="-262" y="-579" z="0" />
@@ -3486,7 +3486,7 @@
     <arc exit="south" move="south" destination="542" />
     <arc exit="go" move="go door" destination="535" />
   </node>
-  <node id="544" name="Kertigen's Temple, Apse" note="Shrine4-10|Kertigen" color="#4080FF">
+  <node id="544" name="Kertigen's Temple, Apse" note="Shrine4-10|Kertigen" color="#A6A3D9">
     <description>Although there are no pews for worshippers to rest on, here at the front of the temple are several long wooden benches.  A curved railing shaped much like the bow of a ship encloses the altar, protecting and framing it splendidly.</description>
     <position x="-372" y="-479" z="0" />
     <arc exit="north" move="north" destination="542" />
@@ -3557,12 +3557,12 @@
     <arc exit="out" move="out" destination="522" />
     <arc exit="go" move="go cave" destination="556" />
   </node>
-  <node id="556" name="Everild's Temple, Inside the Cave" note="Shrine4-06|Everild" color="#4080FF">
+  <node id="556" name="Everild's Temple, Inside the Cave" note="Shrine4-06|Everild" color="#A6A3D9">
     <description>The small cave provides a rustic setting for the boar statue, which is made of cold bronze.  Although poised as if sleeping, its body is tense and a single open eye appears to watch every movement.</description>
     <position x="-312" y="-469" z="0" />
     <arc exit="out" move="out" destination="555" />
   </node>
-  <node id="557" name="Damaris' Temple, Altar Hall" note="Shrine4-07|Damaris" color="#4080FF">
+  <node id="557" name="Damaris' Temple, Altar Hall" note="Shrine4-07|Damaris" color="#A6A3D9">
     <description>A long narrow hall focuses attention on an altar at the western end.  The only ornament is the floor, an image of an elongated panther created from black marble floor tiles set against white shimmering stone.  The paws of the panther embrace the altar, and its tail curves around to the door leading outside the temple.</description>
     <position x="-162" y="-489" z="0" />
     <arc exit="north" move="north" destination="558" />
@@ -4270,7 +4270,7 @@
     <position x="318" y="-579" z="0" />
     <arc exit="east" move="east" destination="664" />
   </node>
-  <node id="666" name="Urrem'tier's Temple, Dark Alcove" note="Shrine4-04|Urrem'tier" color="#4080FF">
+  <node id="666" name="Urrem'tier's Temple, Dark Alcove" note="Shrine4-04|Urrem'tier" color="#A6A3D9">
     <description>Snickering noises echo in the alcove, or maybe it is the unknown breeze that chills the air even colder here than in the outer room.  Shadows dance on the walls yet there is no light source visible to cause them.  A larger than life onyx scorpion statue stands menacingly in the middle of the room.</description>
     <position x="358" y="-579" z="0" />
     <arc exit="out" move="out" destination="664" />
@@ -5235,7 +5235,7 @@
     <position x="202" y="541" z="0" />
     <arc exit="west" move="west" destination="805" />
   </node>
-  <node id="807" name="Glythtide's Shrine" note="Shrine4-08|Glythtide" color="#4080FF">
+  <node id="807" name="Glythtide's Shrine" note="Shrine4-08|Glythtide" color="#A6A3D9">
     <description>The shrine room is shaped like a burrow, all corners rounded and smooth.  Mown grasses and meadowsweet stems cover the floor in a fragrant strewing, but the main focus of the shrine remains the statue honoring the god Glythtide.</description>
     <position x="148" y="-509" z="0" />
     <arc exit="out" move="out" destination="444" />

--- a/Map90_Ratha.xml
+++ b/Map90_Ratha.xml
@@ -4014,7 +4014,7 @@
     <arc exit="east" move="east" destination="587" />
     <arc exit="west" move="west" destination="625" />
   </node>
-  <node id="627" name="Eluned's Temple, Pool" note="Pool" color="#0000A0">
+  <node id="627" name="Eluned's Temple, Pool" note="Pool" color="#000080">
     <description>A rock protrudes, but it does not appear to be the bottom of the pool.  The cold water swirls in a strong current here.</description>
     <position x="-372" y="-599" z="0" />
     <arc exit="up" move="swim up" destination="554" />

--- a/Map92_Ratha_NW.xml
+++ b/Map92_Ratha_NW.xml
@@ -136,27 +136,27 @@
     <arc exit="northeast" move="northeast" destination="22" />
     <arc exit="southwest" move="southwest" destination="20" />
   </node>
-  <node id="22" name="Reshalia Trade Road, Farmland" color="#808040">
+  <node id="22" name="Reshalia Trade Road, Farmland">
     <description>The road takes a sharp turn here at the corner of a field.  The ground underfoot is soft and squishy, with frequent stretches that are downright slippery.  The smell of healthy, wet slime gives you a clue as to why this piece of road is so hazardous -- it's very muddy and oozy.</description>
     <description>The road takes a sharp turn here at the corner of a field.  The farmer who tends this land is a little overly enthusiastic about filling the drainage ditches, and water spills over onto the road somewhere to the northwest, making this stretch soggy.  A wide variety of slimes and mosses have taken over different ruts and corners, making all this mud most interesting for a dedicated natural philosopher, and a slippery nuisance for everyone else.</description>
     <position x="300" y="100" z="0" />
     <arc exit="southwest" move="southwest" destination="21" />
     <arc exit="northwest" move="northwest" destination="23" />
   </node>
-  <node id="23" name="Reshalia Trade Road, Farmland" color="#808040">
+  <node id="23" name="Reshalia Trade Road, Farmland">
     <description>A pedal mill stands astride the irrigation ditch to one side of the road.  The surface of the road here is wet and muddy -- it looks like water slops over out of the ditch on a regular basis.</description>
     <description>Two large Gor'Togs, a male and a female, work side by side on a pedal-mill.  Constructed of old lumber lashed together, the rickety contraption lifts water out of the flowing irrigation ditch and dumps it into the smaller ditch leading off into the kord field west of the road.  One of the small buckets on the male's side of the machine is cracked, causing it to spill water onto the road whenever it comes around.</description>
     <position x="280" y="80" z="0" />
     <arc exit="southeast" move="southeast" destination="22" />
     <arc exit="northwest" move="northwest" destination="24" />
   </node>
-  <node id="24" name="Reshalia Trade Road, Farmland" color="#808040">
+  <node id="24" name="Reshalia Trade Road, Farmland">
     <description>The occasional crunch underfoot is caused by gravel strewn in the road, apparently in an attempt to improve the footing in the muddy ruts.  It's a futile effort, however, since the gravel simply sinks into the mud and vanishes whenever it's walked on.  The road is wet and slippery, and the gravel only serves to bring to mind the likelihood of a few nasty cuts if one takes a spill, in addition to the inevitable mud on one's clothes.</description>
     <position x="260" y="60" z="0" />
     <arc exit="southeast" move="southeast" destination="23" />
     <arc exit="northwest" move="northwest" destination="25" />
   </node>
-  <node id="25" name="Reshalia Trade Road, Farmland" color="#808040">
+  <node id="25" name="Reshalia Trade Road, Farmland">
     <description>To the west, in a corner where two kord fields meet at an angle, is a small rocky spot where the farmers have built a wooden shrine.  A path planted on either side with daisies and ornamental grasses leads to the cozy structure.  Two stone cows lie on either side of the path, their necks garlanded with wilted daisy wreaths, their carved eyes flat and glazed looking.</description>
     <position x="240" y="40" z="0" />
     <arc exit="north" move="north" destination="26" />

--- a/Map92_Ratha_NW.xml
+++ b/Map92_Ratha_NW.xml
@@ -421,27 +421,27 @@
     <arc exit="east" move="east" destination="67" />
     <arc exit="southwest" move="southwest" destination="65" />
   </node>
-  <node id="67" name="Reshalia, Abandoned Road" note="Silver Leucros" color="#C0C0C0">
+  <node id="67" name="Reshalia, Abandoned Road" note="Silver Leucros">
     <description>This branch of the road narrowly skirts a large gravel pit just to the north, but it shows no sign of through traffic by the gravel carts.  Tracks lead to the west, as if carts were sometimes stored here, but none continue down the road.  Instead, weeds and briars appear increasingly in the wheel ruts to the east.</description>
     <position x="520" y="-340" z="0" />
     <arc exit="east" move="east" destination="68" />
     <arc exit="west" move="west" destination="66" />
   </node>
-  <node id="68" name="Reshalia, Abandoned Road" color="#C0C0C0">
+  <node id="68" name="Reshalia, Abandoned Road">
     <description>A rutted road stretches east and west, but it is so overgrown with weeds that it must be a long while since it has seen many travelers.  To the north yawns a great space -- the gravel pit, filled with the shouts of laborers by day, but now dark and silent.  A dark forest, thickly grown, lies to the south of the road.</description>
     <description>A rutted road stretches east and west, but it is so overgrown with weeds that it must be a long while since it has seen many travelers.  To the north yawns a great open gravel pit, filled with the shouts of laborers and the clatter of their tools.  A dark forest, thickly grown, lies to the south of the road.</description>
     <position x="540" y="-340" z="0" />
     <arc exit="east" move="east" destination="69" />
     <arc exit="west" move="west" destination="67" />
   </node>
-  <node id="69" name="Reshalia, Abandoned Road" color="#C0C0C0">
+  <node id="69" name="Reshalia, Abandoned Road">
     <description>Low scrub covers the road and the broken wagon wheel that once traveled it.  The underbrush has returned, burying the traces of passage except to the west, where ruts can still be made out.  Gaps appear in the encircling trees to the north and northeast, although which of them was the road is hard to say.</description>
     <position x="560" y="-340" z="0" />
     <arc exit="north" move="north" destination="71" />
     <arc exit="northeast" move="northeast" destination="70" />
     <arc exit="west" move="west" destination="68" />
   </node>
-  <node id="70" name="Abandoned Road, The Briar Wood" color="#C0C0C0">
+  <node id="70" name="Abandoned Road, The Briar Wood">
     <description>From all around, both close by and deep in the woods, come strange sounds, sounds out of place in this wilderness.  One is caught in mid-step, even in mid-breath, by the very oddity of the noises -- clicks, a rasp of metal on stone, a half-liquid slither.</description>
     <description>Although trees and high underbrush line this crossing of what may be game trails, the ground looks more open to the southwest.  Shifting patches of light pierce the dense crown above, and a darker path heads east, deeper into the wood.</description>
     <position x="580" y="-360" z="0" />
@@ -450,7 +450,7 @@
     <arc exit="southwest" move="southwest" destination="69" />
     <arc exit="west" move="west" destination="71" />
   </node>
-  <node id="71" name="Abandoned Road, The Pit Edge" color="#C0C0C0">
+  <node id="71" name="Abandoned Road, The Pit Edge">
     <description>To the west is the unmistakable feel of a vast open space, threatening in its emptiness.  But if one yields to the pressure of the wilderness to the east and edges away from the hidden dangers of the wood, one false step could mean a stumble, a fall, and an unheard cry.</description>
     <description>The road, sunken from former traffic, stands well away from the edge of the massive pit to the west.  To the north, the road continues, obscured somewhat by dust rising from the gravel quarry.  A trail leads off through the foliage to the east.</description>
     <position x="560" y="-360" z="0" />
@@ -458,13 +458,13 @@
     <arc exit="east" move="east" destination="70" />
     <arc exit="south" move="south" destination="69" />
   </node>
-  <node id="72" name="Abandoned Road, The Briar Wood" color="#C0C0C0">
+  <node id="72" name="Abandoned Road, The Briar Wood">
     <description>The path opens into a clearing that looks oddly regular in the darkness.  A musty scent like damp ash fills the air.  The smell is faint but fresh, as if something has recently been burned or scorched then doused.</description>
     <description>In the midst of thorns and briars, ringed by a high wall of dark cedars, lies a perfectly circular clearing.  Although weeds fill the center, footprints all around the edge of the clearing show where countless feet have beaten the ground cover to the bare earth.</description>
     <position x="600" y="-360" z="0" />
     <arc exit="west" move="west" destination="70" />
   </node>
-  <node id="73" name="Abandoned Road, The Briar Wood" color="#C0C0C0">
+  <node id="73" name="Abandoned Road, The Briar Wood">
     <description>The air in this maze of paths is still and heavy with a sharp medicinal odor.  The silence is broken from time to time by a falling drop, although the interlocked needles overhead shelter the area from all but the fiercest storms.</description>
     <description>Overhead the sky is nearly blotted out by the crowns of trees fighting for sunlight.  Some of the thorn bushes beneath them bear droplets of a clear liquid, thick and oily, with a scent vaguely like camphor.</description>
     <position x="580" y="-380" z="0" />
@@ -474,7 +474,7 @@
     <arc exit="south" move="south" destination="70" />
     <arc exit="west" move="west" destination="74" />
   </node>
-  <node id="74" name="Abandoned Road, The Pit Edge" color="#C0C0C0">
+  <node id="74" name="Abandoned Road, The Pit Edge">
     <description>A vast, black emptiness stretches west and north.  With the yawning void on one side and the forest on the other, the sense of vulnerability is oppressive, as if the place offers no protection and no escape.</description>
     <description>The road curves to the northeast, avoiding a gap where the edge has collapsed.  From the pile of rock and rubble far below, the crumbling of the edge must have been spectacular.  Travelers on foot, perhaps giving the gap a wider berth, have beaten a shortcut through the dark briar wood to the east.</description>
     <position x="560" y="-380" z="0" />
@@ -482,7 +482,7 @@
     <arc exit="east" move="east" destination="73" />
     <arc exit="south" move="south" destination="71" />
   </node>
-  <node id="75" name="Abandoned Road, The Pit Edge" color="#C0C0C0">
+  <node id="75" name="Abandoned Road, The Pit Edge">
     <description>A misstep in the darkness at the edge of the pit would surely be fatal, and the traveler does well here to rely on the feel of the ground underfoot.  The wood to the east may offer more security -- or only danger of a different kind.</description>
     <description>More a path than a road, the way circles the gap where the pit edge has crumbled away.  The new face is almost vertical, eroded deeply and as yet untamed by plant or weather.  The gravel miners far down in the pit seem to avoid the area just below the gap, perhaps from bitter experience.</description>
     <position x="580" y="-400" z="0" />
@@ -491,13 +491,13 @@
     <arc exit="southwest" move="southwest" destination="74" />
     <arc exit="northwest" move="northwest" destination="79" />
   </node>
-  <node id="76" name="Abandoned Road, The Briar Wood" color="#C0C0C0">
+  <node id="76" name="Abandoned Road, The Briar Wood">
     <description>No description could be more appropriate for this small clearing than dead in dead end.  It's hard to say where the hint of death comes from, for the surrounding trees sound lively enough, shifting and rustling as if moved by a breeze.  Even when there is no breeze.</description>
     <description>A small clearing is encircled by a wall of dense undergrowth broken only by the path leading in.  Although the firm, dry area would make a fine campsite, there is no sign of visitors -- no empty bottles or wineskins, no discarded broken gear, not even the ashes of an old fire.</description>
     <position x="600" y="-380" z="0" />
     <arc exit="west" move="west" destination="73" />
   </node>
-  <node id="77" name="Abandoned Road, The Briar Wood" color="#C0C0C0">
+  <node id="77" name="Abandoned Road, The Briar Wood">
     <description>Briars snag the unwary wayfarer at each pace, and thick, dark-green cedars limit vision except to the west.  In that direction, the path around the pit lies in plain view, although the watcher is well hidden by brush.  It seems a place made for waiting in ambush.</description>
     <description>This part of the wood, not far from the path around the gravel pit, sees few hunters, to judge by the wild growth of the brush on every side except to the west.  And it all seems to have thorns: if anything besides briars, nettles, holly, and thornbush grows here, it must be out of season.</description>
     <position x="600" y="-400" z="0" />
@@ -505,7 +505,7 @@
     <arc exit="southwest" move="southwest" destination="73" />
     <arc exit="west" move="west" destination="75" />
   </node>
-  <node id="78" name="Abandoned Road, The Briar Wood" color="#C0C0C0">
+  <node id="78" name="Abandoned Road, The Briar Wood">
     <description>Even in the darkness, it's apparent this is an open area of some size.  From time to time spots of light appear, dim reddish dots.  They look to be about the height of a Halfling above the ground, showing up briefly, sometimes moving, then disappearing as quickly as they came.</description>
     <description>A secluded dell offers welcome relief from snagging thorns and tripping vines.  Thick grass cushions the ground and invites the weary to pause and rest.  The noise and dust of the gravel pit are only memories here, almost part of a different world.</description>
     <position x="620" y="-400" z="0" />

--- a/Map95_Ratha_NE.xml
+++ b/Map95_Ratha_NE.xml
@@ -477,7 +477,7 @@
     <arc exit="east" move="east" destination="78" />
     <arc exit="west" move="west" destination="76" />
   </node>
-  <node id="78" name="Pokekehekepi olpo'staho" color="#008080">
+  <node id="78" name="Pokekehekepi olpo'staho">
     <description>Glistening with a silver sheen, the sands stretch out into the darkness beyond the range of vision.</description>
     <description>Gleaming golden sand stretches out, seemingly endless under the glaring light of the daytime sun.</description>
     <position x="560" y="-210" z="0" />
@@ -2083,7 +2083,7 @@
     <arc exit="east" move="east" destination="288" />
     <arc exit="southwest" move="southwest" destination="291" />
   </node>
-  <node id="291" name="Peltahp'staho" color="#008080">
+  <node id="291" name="Peltahp'staho">
     <description>Pinched into this corner is a mound of earth shaped into a ramp angled up towards the dark shadows of the ceiling.  Bits of luminous mycelium hang in what appear to be intentionally cultivated curtains, giving off a soft glow.</description>
     <position x="220" y="-300" z="0" />
     <arc exit="north" move="north" destination="292" />

--- a/Map95_Ratha_NE.xml
+++ b/Map95_Ratha_NE.xml
@@ -1964,7 +1964,7 @@
     <arc exit="east" move="east" destination="271" />
     <arc exit="west" move="west" destination="273" />
   </node>
-  <node id="273" name="Peltaph'staho" note="Disease Wall" color="#C0C0C0">
+  <node id="273" name="Peltaph'staho" note="Disease Wall">
     <description>The floor here is littered with pebbles and grit from what looks like a partial cave-in.  The walls are craggy and split, and moist with some kind of clear fluid.</description>
     <position x="400" y="-340" z="0" />
     <arc exit="east" move="east" destination="272" />
@@ -2141,7 +2141,7 @@
     <position x="280" y="-360" z="0" />
     <arc exit="west" move="west" destination="298" />
   </node>
-  <node id="300" name="Peltaph'staho" note="Disease Wall 2" color="#C0C0C0">
+  <node id="300" name="Peltaph'staho" note="Disease Wall 2">
     <description>The floor here is littered with pebbles and grit from what looks like a partial cave-in.  The walls are craggy and split, and moist with some kind of clear fluid.</description>
     <position x="280" y="-400" z="0" />
     <arc exit="northeast" move="northeast" destination="301" />
@@ -2149,7 +2149,7 @@
     <arc exit="southwest" move="southwest" destination="297" />
     <arc exit="northwest" move="northwest" destination="302" />
   </node>
-  <node id="301" name="Peltaph'staho" note="Disease Wall 3" color="#C0C0C0">
+  <node id="301" name="Peltaph'staho" note="Disease Wall 3">
     <description>The floor here is littered with pebbles and grit from what looks like a partial cave-in.  The walls are craggy and split, and moist with some kind of clear fluid.</description>
     <position x="300" y="-420" z="0" />
     <arc exit="north" move="north" destination="303" />

--- a/Map95_Ratha_NE.xml
+++ b/Map95_Ratha_NE.xml
@@ -985,7 +985,7 @@
     <arc exit="east" move="east" destination="145" />
     <arc exit="southwest" move="southwest" destination="143" />
   </node>
-  <node id="145" name="Pokekehekepi olpo'staho" color="#800000">
+  <node id="145" name="Pokekehekepi olpo'staho">
     <description>Glistening with a silver sheen, the sands stretch out into the darkness beyond the range of vision.</description>
     <description>Gleaming golden sand stretches out, seemingly endless under the glaring light of the daytime sun.</description>
     <position x="820" y="-470" z="0" />
@@ -2284,7 +2284,7 @@
     <arc exit="east" move="east" destination="322" />
     <arc exit="southwest" move="southwest" destination="320" />
   </node>
-  <node id="322" name="Peltaph'staho" color="#800000">
+  <node id="322" name="Peltaph'staho">
     <description>Pinched into this corner is a mound of earth shaped into a ramp angled up towards the dark shadows of the ceiling.</description>
     <position x="500" y="-520" z="0" />
     <arc exit="southwest" move="southwest" destination="323" />

--- a/MapTF1_The_Arch.xml
+++ b/MapTF1_The_Arch.xml
@@ -59,7 +59,7 @@
     <arc name="west" hidden="False" destination="7" />
     <arc name="go doorway" hidden="False" destination="15" />
   </node>
-  <node id="9" name="Droughtman's Maze, Observation Deck" note="Heal Room" color="#80FFFF">
+  <node id="9" name="Droughtman's Maze, Observation Deck" note="Heal Room" color="#00BF80">
     <description>Light seems to follow you as you move about, allowing you to see what's in front of you but very little of what's beyond.  A slight odor of peaches is prevalent throughout the hallway.</description>
     <position x="180" y="140" z="0" />
     <arc name="northeast" hidden="False" destination="10" />

--- a/Quests (Spoiler Alert) Copy to the Maps Folder/Beyond_the_Barrier.xml
+++ b/Quests (Spoiler Alert) Copy to the Maps Folder/Beyond_the_Barrier.xml
@@ -132,7 +132,7 @@
     <position x="920" y="300" z="0" />
     <arc exit="south" move="south" destination="21" />
   </node>
-  <node id="23" name="The Great Barrier, Rift" color="#800000">
+  <node id="23" name="The Great Barrier, Rift">
     <description>A visible tear in the Great Barrier churns with maddening chaos, the edges of it resembling an open wound.  Hints of a desolate forest are visible through the rift, although the break shifts and changes constantly.  Faint scraps of a dark purple cloth cling to the ground in ragged threads, as if the rift was traversed recently and with great difficulty.</description>
     <position x="880" y="180" z="0" />
     <arc exit="northeast" move="northeast" destination="24" />
@@ -150,7 +150,7 @@
     <position x="880" y="140" z="0" />
     <arc exit="southeast" move="southeast" destination="24" />
   </node>
-  <node id="26" name="Western Wastelands, Dead Forest" color="#800000">
+  <node id="26" name="Western Wastelands, Dead Forest">
     <description>Skeletal, finger-like branches of bare trees reach up toward the blighted heavens, cracked and crumbling.  Not a scrap of green remains, even the old leaves long crumbled away to a greyish dust.  Jagged rocks poke up through the withered roots, exposed solely due to the complete lack of undergrowth.</description>
     <position x="720" y="180" z="0" />
     <arc exit="west" move="west" destination="27" />


### PR DESCRIPTION
## Summary

Follow-up cleanup after #227 (HexConvert). Every `color="#..."` attribute
in the repo was inventoried, classified, and manually validated against the
documented color legend in [README.txt](README.txt). 213 non-standard hex
code occurrences across 16 unique codes have been processed in this PR.

After this PR, every `color="#..."` attribute in the repo's XML files uses
one of the 16 documented legend colors. Verification: `git grep -E 'color="#'`
combined with a filter for non-legend hexes returns zero matches.

## Two kinds of changes

### 7 semantic conversions (right meaning, wrong shade)

These nodes already represented something covered by the legend - they just
weren't using the standard hex code. Direct semantic corrections:

| From      | To        | Why                                                                |
|-----------|-----------|--------------------------------------------------------------------|
| `#010165` | `#000080` Navy      | 10 "Segoltha River, Midstream" rooms (RGB distance 27 from Navy) |
| `#4080FF` | `#A6A3D9` Periwinkle | 11 deity shrine rooms (Trothfang, Hodierna, Phelim, Chadatru, Faenella, Kertigen, Everild, Damaris, Urrem'tier, Glythtide, Dark Aspects) |
| `#0000A0` | `#000080` Navy      | Eluned's Temple Pool (id 627, drowning pool)                       |
| `#0080FF` | `#0000FF` Blue      | Eluned's Temple Pool (id 554, swimming pool)                       |
| `#80FF00` | `#FF8000` Orange    | Moon Mage Guildleader (probable byte-swap typo of Orange)          |
| `#80FFFF` | `#00FFFF` Aqua      | 53 Ratha Shh'o'kumu Terrace PC housing district rooms              |
| `#80FFFF` | `#00BF80` Mint      | 1 Droughtman's Maze "Heal Room" (auto-healer)                      |

### 10 strips (undocumented colors)

These hex codes have no meaning in README.txt's legend. Stripping the
attribute lets the rooms render with the default color; semantic
information (where present) is preserved in each node's `note` field:

| Hex       | Count | Notes                                                  |
|-----------|-------|--------------------------------------------------------|
| `#C0C0C0` | 60    | Silver - misc city/wilderness rooms across 6 maps      |
| `#A020F0` | 17    | X11 "purple" (not standard Purple #800080) - hunting bookmarks in Map108 |
| `#808000` | 13    | Olive - used informally as "Kraelyst travel start" marker; semantic preserved in note fields |
| `#808080` | 21    | Medium gray - mudflats, bog wallows, passages          |
| `#804000` | 6     | Brown - Catacombs and Manor Grounds in Map63           |
| `#808040` | 5     | Dark olive - Gate / Farmland rooms                     |
| `#000000` | 5     | Black - Forlorn Hope caverns                           |
| `#800000` | 4     | Maroon - 2 nodes in Map95 + 2 in Beyond_the_Barrier quest map |
| `#008080` | 2     | Teal - 2 unique-named rooms in Map95                   |
| `#FF0080` | 2     | Pink - 2 Ratha street rooms                            |

## Verification

- Zero non-standard hex codes remain in any of the 132 XML files
- All UTF-8 BOMs preserved where they originally existed
- Every commit is balanced (equal insertions / deletions)
- Each decision has its own commit with rationale in the message

## Test plan

- [ ] Spot-check a converted node in Genie's automapper (e.g. Eluned's
      Temple Pool nodes) to confirm new colors render as expected
- [ ] Spot-check a stripped node (e.g. a Mer'Kresh Gull Circle room) to
      confirm it renders with the default color
- [ ] Verify shrine rooms (now Periwinkle) display the same as other
      Periwinkle shrines in the repo

## Relationship to #227

Independent of #227 (HexConvert) - that PR only touched named colors
(`Aqua`, `Red`, etc.) and the undocumented `White` named color. This PR
only touches hex codes (`#XXXXXX` form). The two can merge in either
order. Combined, they bring the repo to 100% legend-compliant color usage.