### PR TITLE
Crossing and Temporal Pocket

### DIFF
--- a/Map1_Crossing.xml
+++ b/Map1_Crossing.xml
@@ -3164,6 +3164,7 @@
     <arc exit="east" move="east" destination="469" />
     <arc exit="out" move="out" hidden="True" destination="29" />
     <arc exit="go" move="go mirrorlike portal" destination="470" />
+	<arc exit="go" move="go gold-gilded archway" destination="1058" />
   </node>
   <node id="469" name="Bards' Guild, Repair Room">
     <description>Shelves upon shelves of half-built mandolins, violins, lutes, flutes, and a slew of other unidentifiable parts cover the walls.  The scent of rosin and glue wafts in the air.  In the corner, a long sturdy workbench holds a plethora of specialized tools to aid in the crafting of the finest musical instruments.</description>
@@ -4493,6 +4494,7 @@
     <position x="-202" y="142" z="0" />
     <arc exit="out" move="out" destination="59" />
     <arc exit="go" move="go crate" destination="674" />
+	<arc exit="go" move="go silver portal" destination="1060" />
   </node>
   <node id="674" name="Aesthene's Close, Chamber">
     <description>You find yourself on a slimy cobblestone floor in a dark, dank and smelly chamber.  Noxious trickles of effluent seep through tiny cracks in the tortured walls, which appear to be on the verge of collapse.  The hole in the rotted timber high above is hardly convenient for escape, and you realize with a chill that you must find another way out.</description>
@@ -6782,6 +6784,32 @@
     <description>Ornate bronze lampposts stand opposite the opulent manors stacked along the avenue, dormant for the day.  Across the river to the east, the High Temple can be seen rising majestically over Longbow Bridge, its brightly burning beacon flames visible even against the daytime sky.</description>
     <position x="140" y="130" z="1" />
     <arc exit="north" move="north" destination="1052" />
+  </node>
+  <node id="1058" name="Bard's Guild, The Quill and Quaver" note="quill|quill and quaver" color="#FF0000">
+    <description>Ruby-red banners hang from the upper walls, edged with thin gold trim, while brass windchimes shaped like tiny harps and lute silhouettes are suspended from overhead beams.  The floor is composed of dark hardwood planks, and one wall bears a series of mounted, polished metal strings stretched across small frames, their tension creating straight, taut lines strung with glass music notes.</description>
+    <position x="-64" y="-336" z="0" />
+    <arc exit="east" move="east" destination="1059" />
+	<arc exit="go" move="go gold-gilded archway" destination="468" />
+  </node>
+  <node id="1059" name="Bard's Guild, The Quill and Quaver" color="#FF0000">
+    <description>Dark hardwood covers the floor in wide, uniform boards, intersected by a narrow strip of lighter inlay along the perimeter.  The walls are painted deep ruby and punctuated with small golden sconces, each shaped like giant zills.  Hanging from iron brackets are metal wind bells shaped like tiny flutes, their surfaces polished to a reflective shine.  Sections of the wall feature vertical panels of ruby-colored fabric with fine gold embroidery in repeating stave and clef motifs.</description>
+    <position x="-54" y="-336" z="0" />
+    <arc exit="west" move="west" destination="1058" />
+  </node>
+  <node id="1060" name="Temporal Pocket, Nexus" note="Map516q_Temporal_Pocket.xml|temporal pocket">
+     <description>Shifting colors pulse across the sky, oscillating in a fluctuating random pattern admidst the shattered shards of the sky.  More shards jumbled together comprise a floor drifting above the bottomless void.</description>
+    <position x="-202" y="162" z="0" />
+    <arc exit="north" move="north" />
+    <arc exit="northeast" move="northeast" />
+    <arc exit="east" move="east" />
+    <arc exit="southeast" move="southeast" />
+    <arc exit="south" move="south" />
+    <arc exit="southwest" move="southwest" />
+    <arc exit="west" move="west" />
+    <arc exit="northwest" move="northwest" />
+    <arc exit="go" move="go circular wall" />
+	<arc exit="go" move="go silver portal" destination="673" />
+	<arc exit="go" move="go gold vortex" />
   </node>
   <label text="Shipyard">
     <position x="-20" y="314" z="0" />

--- a/Quests (Spoiler Alert) Copy to the Maps Folder/Map516q_Temporal_Pocket.xml
+++ b/Quests (Spoiler Alert) Copy to the Maps Folder/Map516q_Temporal_Pocket.xml
@@ -12,6 +12,8 @@
     <arc exit="west" move="west" destination="8" />
     <arc exit="northwest" move="northwest" destination="9" />
     <arc exit="go" move="go circular wall" destination="10" />
+	<arc exit="go" move="rt go silver portal" destination="11" />
+	<arc exit="go" move="go gold vortex" destination="12" />
   </node>
   <node id="2" name="Temporal Pocket, Akigwe's Tower" note="Akigwe's Legacy|tower">
     <description>A layer of dust covers everything here.  High above, a crystal sits atop the tower before you and slowly flickers from one color to another, endlessly casting odd shadows throughout the cavern.</description>
@@ -58,6 +60,38 @@
     <position x="155" y="130" z="0" />
     <arc exit="go" move="go circular wall" destination="1" />
   </node>
+  <node id="11" name="Old Warehouse" note="Map1_Crossing.xml|crossing|exit">
+    <description>The reek of dead fish permeates your nostrils making you feel ill.  Besides the stench, you notice piles and piles of old crates almost entirely filling this rotting deobar-paneled warehouse.  One of the crates in the corner has been smashed open, straw and broken glass spilling across the floor from it.</description>
+    <position x="140" y="180" z="0" />
+    <arc exit="out" move="out" />
+    <arc exit="go" move="go crate" />
+	<arc exit="go" move="go silver portal" destination="1" />
+  </node>
+  <node id="12" name="Temporal Prizes, Lormandu" color="#FF0000" note="end loot|loot|prizes|lormandu">
+    <description>Shifting colors pulse overhead, oscillating in a swirling floral pattern amidst the shattered shards of a dark fathomless sky.  Fragrant wildflowers are heaped together and form a floor of blossoms that drifts aimlessly above a bottomless void.</description>
+    <position x="200" y="260" z="0" />
+    <arc exit="southeast" move="southeast" destination="13" />
+	<arc exit="southwest" move="southwest" destination="15" />
+	<arc exit="go" move="go gold vortex" destination="1" />
+  </node>
+  <node id="13" name="Temporal Prizes, Anlandu" color="#FF0000" note="anlandu">
+    <description>Shifting colors pulse overhead, oscillating in a dynamic sunburst pattern amidst the shattered shards of a dark fathomless sky.  Sheaves of grain are stacked together and form a harvest floor that drifts aimlessly above a bottomless void.</description>
+    <position x="220" y="280" z="0" />
+    <arc exit="northwest" move="northwest" destination="12" />
+	<arc exit="southwest" move="southwest" destination="14" />
+  </node>
+  <node id="14" name="Temporal Prizes, Blufandu" color="#FF0000" note="blufandu">
+    <description>Shifting colors pulse overhead, oscillating in a falling leaf pattern amidst the shattered shards of a dark fathomless sky.  Red and gold leaves are piled together and form a floor of foliage that drifts aimlessly above a bottomless void.</description>
+    <position x="200" y="300" z="0" />
+    <arc exit="northeast" move="northeast" destination="13" />
+	<arc exit="northwest" move="northwest" destination="15" />
+  </node>
+  <node id="15" name="Temporal Prizes, Jeolandu" color="#FF0000" note="jeolandu">
+    <description>Shifting colors pulse overhead, oscillating in an intricate snowflake pattern amidst the shattered shards of a dark fathomless sky.  Jagged sheets of ice form a frosty floor that drifts aimlessly above a bottomless void.</description>
+    <position x="180" y="280" z="0" />
+    <arc exit="northeast" move="northeast" destination="12" />
+	<arc exit="southeast" move="southeast" destination="14" />
+  </node>
   <label text="Akigwe's Legacy">
     <position x="120" y="80" z="0" />
   </label>
@@ -74,12 +108,15 @@
     <position x="120" y="190" z="0" />
   </label>
   <label text="Quelling the Riot">
-    <position x="50" y="155" z="0" />
+    <position x="40" y="155" z="0" />
   </label>
   <label text="Morun Melgorehn">
-    <position x="25" y="130" z="0" />
+    <position x="15" y="130" z="0" />
   </label>
   <label text="Ghost Ship">
-    <position x="75" y="110" z="0" />
+    <position x="70" y="110" z="0" />
+  </label>
+  <label text="End Loot">
+    <position x="110" y="270" z="0" />
   </label>
 </zone>


### PR DESCRIPTION
Added rooms for The Quill and Quaver to Crossing, as well as linking the old warehouse to the Temporal Pocket map. Updated the Temporal Pocket to link back to Crossing, and added the end loot rooms.

# Pull Request

## Summary

Added rooms for The Quill and Quaver shop in the Crossing Bard guild hall, and linked the old warehouse to the Temporal Pocket map. Linked the Temporal Pocket map back to Crossing, added the end loot rooms, and cleaned up the label positioning a little.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Plugin update
- [x] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Closes #

## Testing

Ran through the related areas manually, using #goto, and using the automapper.

## Checklist

- [x] I kept this pull request focused and reasonably scoped
- [x] I tested the change where practical
- [x] I updated documentation if needed
- [x] I understand this contribution will be distributed under the repository’s existing license
